### PR TITLE
Fix pubDate timezone and handle invalid dates

### DIFF
--- a/data/news.json
+++ b/data/news.json
@@ -1,355 +1,355 @@
 {
-  "lastUpdate": "2025-08-24T16:51:14.144599Z",
+  "lastUpdate": "2025-08-24T17:23:10.810793Z",
   "news": {
     "World": [
+      {
+        "title": "LIVE: Real Oviedo vs Real Madrid – La Liga",
+        "link": "https://www.aljazeera.com/sports/liveblog/2025/8/24/live-real-oviedo-vs-real-madrid-la-liga?traffic_source=rss",
+        "description": "Follow the build-up, analyses and live text commentary of the game as Oviedo host Real Madrid in Spain's La Liga.",
+        "pubDate": "2025-08-24T16:40:00Z",
+        "source": "aljazeera.com"
+      },
       {
         "title": "Why protesters in the UK are being arrested under ‘terror’ laws",
         "link": "https://www.aljazeera.com/video/the-stream/2025/8/24/why-protesters-in-the-uk-are-being-arrested-under-terror-laws?traffic_source=rss",
         "description": "Why some protests in the UK are being criminalised, and what that means for free speech.",
-        "pubDate": "2025-08-24T15:46:30",
+        "pubDate": "2025-08-24T15:46:30Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Moscow says Russia and Ukraine exchange 146 prisoners each",
         "link": "https://www.aljazeera.com/news/2025/8/24/moscow-says-russia-and-ukraine-exchange-146-prisoners-each?traffic_source=rss",
         "description": "The exchange comes amid diplomatic efforts to solve the conflict and a Ukrainian drone attack on Russia overnight.",
-        "pubDate": "2025-08-24T14:57:09",
+        "pubDate": "2025-08-24T14:57:09Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Trump says he’ll be at Ryder Cup and he thinks captain Keegan Bradley should play - AP News",
         "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxQX1h6a2ExMk1LRHpoYXlKUTlZNVhuT0d4aExmdG52Q2E4NWFKN1BvTEJCajVOZjk0V21rWWpkOEhsNUliSlBCREpjdXl4Q04yalh1UGFWUy1HbzNJZ3hrc1hyQnV0R3Rab2I3dDI3TGUxSzdxdFh6eEQwQ1JTaFlBQ3dVRUY5NW1NcnZwMElScmVOZDhPVlFqWFFlcF96aUp6?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T14:42:00",
+        "pubDate": "2025-08-24T14:42:00Z",
         "source": "news.google.com"
       },
       {
         "title": "More than 30 jihadists killed in air strikes, Nigerian military says",
         "link": "https://www.bbc.com/news/articles/cq58123z814o?at_medium=RSS&at_campaign=rss",
         "description": "Concern is mounting about \"war-time levels of slaughter\" in Nigeria, including a resurgence of jihadist activity.",
-        "pubDate": "2025-08-24T14:38:15",
+        "pubDate": "2025-08-24T14:38:15Z",
         "source": "bbc.com"
       },
       {
         "title": "More than 500,000 ordered to evacuate as typhoon heads for Vietnam",
         "link": "https://www.bbc.com/news/articles/cx2pw5ypwqeo?at_medium=RSS&at_campaign=rss",
         "description": "Typhoon Kajiki is brushing past Hainan in China before heading for Vietnam, forecasters say.",
-        "pubDate": "2025-08-24T14:34:38",
+        "pubDate": "2025-08-24T14:34:38Z",
         "source": "bbc.com"
       },
       {
         "title": "Zelenskyy marks Ukraine Independence Day alongside Canada’s PM in Kyiv",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/zelenskyy-marks-ukraine-independence-day-alongside-canadas-pm-in-kyiv?traffic_source=rss",
         "description": "Ukrainian President Zelenskyy delivered a defiant address against Russia during Ukraine’s Independence Day.",
-        "pubDate": "2025-08-24T14:32:27",
+        "pubDate": "2025-08-24T14:32:27Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Iran will stand up to US demands to be ‘obedient’, says Khamenei",
         "link": "https://www.aljazeera.com/news/2025/8/24/iran-will-not-be-obedient-to-us-nuclear-demands-says-khamenei?traffic_source=rss",
         "description": "The remarks by Supreme Leader Ayatollah Ali Khamenei comes as Tehran agrees to hold nuclear talks with European powers.",
-        "pubDate": "2025-08-24T14:28:06",
+        "pubDate": "2025-08-24T14:28:06Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Maria Sharapova and Bryan Brothers enter tennis hall, with surprise appearance by Serena Williams - AP News",
         "link": "https://news.google.com/rss/articles/CBMipwFBVV95cUxOV0VkUEJPeVl4b0lFb210SWk5SUhaTnNuZXRabHp2TjFUYnB4eXM0UXB4bUtGSUVGUHhVWVpyMU5XNTByY2hDVGhxX2dEXzdycWswbllwa2REZ2RDOXJUNGVTZ1FFcEg3MU04ZmxGOElYMWlXS1hFLXlSV0RUUjQxb2FTN3VOMzZGVXVUTmUtOE53U0Z5MVN4SFJFSmd2OWw2cktGeHctYw?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T14:27:00",
+        "pubDate": "2025-08-24T14:27:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Three sisters drown in migrant boat in Mediterranean, rescuers say",
         "link": "https://www.bbc.com/news/articles/cp89rqgjq1no?at_medium=RSS&at_campaign=rss",
         "description": "There was \"sheer horror\" when survivors realised that the girls aged nine, 11 and 17 had died, a rescuer says.",
-        "pubDate": "2025-08-24T14:26:21",
+        "pubDate": "2025-08-24T14:26:21Z",
         "source": "bbc.com"
       },
       {
         "title": "Zelensky vows to continue fighting as Ukraine marks independence day",
         "link": "https://www.bbc.com/news/articles/czxy2v9dzgxo?at_medium=RSS&at_campaign=rss",
         "description": "Russia said power and energy facilities had been targeted by Ukraine, which accused Russia of \"spreading manipulations\".",
-        "pubDate": "2025-08-24T14:15:28",
+        "pubDate": "2025-08-24T14:15:28Z",
         "source": "bbc.com"
       },
       {
         "title": "Marc Marquez wins Hungarian MotoGP for seventh straight victory",
         "link": "https://www.aljazeera.com/sports/2025/8/24/marc-marquez-wins-hungarian-motogp-for-seventh-straight-victory?traffic_source=rss",
         "description": "The six-time MotoGP world champion is undefeated since June and is rapidly closing in on another riders title.",
-        "pubDate": "2025-08-24T14:11:54",
+        "pubDate": "2025-08-24T14:11:54Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Palestinians fear advancing Israeli assault on Gaza City",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/palestinians-fear-advancing-israeli-assault-on-gaza-city?traffic_source=rss",
         "description": "As Israel advances further in towards Gaza City, Palestinians like Mohammed Zaher fear another forced expulsion.",
-        "pubDate": "2025-08-24T14:08:26",
+        "pubDate": "2025-08-24T14:08:26Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Pro-Palestine protesters rally in cities across Australia",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/pro-palestine-protesters-rally-in-cities-across-australia?traffic_source=rss",
         "description": "Tens of thousands of protesters have demonstrated in cities across Australia in solidarity with Palestinians in Gaza, de",
-        "pubDate": "2025-08-24T13:41:01",
+        "pubDate": "2025-08-24T13:41:01Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Israeli military targets Yemen’s Sanaa after Houthi attacks",
         "link": "https://www.aljazeera.com/news/2025/8/24/israeli-military-targets-yemens-sanaa-after-houthi-attacks?traffic_source=rss",
         "description": "Houthi official says Israeli attacks will not stop group from continuing support for Gaza, 'no matter the sacrifices'.",
-        "pubDate": "2025-08-24T13:39:35",
+        "pubDate": "2025-08-24T13:39:35Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Israel’s targeting of journalists in Gaza continues",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/israels-targeting-of-journalists-in-gaza-continues?traffic_source=rss",
         "description": "A journalist in Gaza reported on the killing of his relatives, live on TV, just hours after losing a colleague.",
-        "pubDate": "2025-08-24T13:32:18",
+        "pubDate": "2025-08-24T13:32:18Z",
         "source": "aljazeera.com"
       },
       {
         "title": "How burgers helped me better understand my Vietnamese immigrant mother",
         "link": "https://www.aljazeera.com/features/2025/8/24/how-burgers-helped-me-better-understand-my-vietnamese-immigrant-mother?traffic_source=rss",
         "description": "Once, eating cheeseburgers allowed my mother to feel American. Now, it shows that she is free to eat what she wants.",
-        "pubDate": "2025-08-24T13:28:54",
+        "pubDate": "2025-08-24T13:28:54Z",
         "source": "aljazeera.com"
       },
       {
         "title": "‘Sopranos’ star Jerry Adler, Broadway backstage vet turned late-in-life actor, dies at 96 - AP News",
         "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxNREl1TzZJTXpUWGl0OXRqMkxjYnBUcldXUFJSeHhrMW9pOWZQbmRLX1BaemhGX1h4U1B4RTZ6cFNrNk9xVllIUGQ3c2kxUDJtcmdOcm85N3l2V2F6RUpvMnpnNFlrWmRwUDI5UFJnRzRRY0VDSTFoaHdqaHVGMjFkZkdWVFZCY1lGbnRoZHU2ekVxX2ZYWUE?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T13:25:00",
+        "pubDate": "2025-08-24T13:25:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Israeli protesters confront far-right Security Minister Itamar Ben-Gvir",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/israeli-protesters-confront-far-right-security-minister-itamar-ben-gvir?traffic_source=rss",
         "description": "A group of protesters confronted Israel's National Security Minister Ben-Gvir, accusing him of pursuing war.",
-        "pubDate": "2025-08-24T13:06:00",
+        "pubDate": "2025-08-24T13:06:00Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Russia accuses Ukraine of attacking nuclear plant, causing a fire",
         "link": "https://www.aljazeera.com/news/2025/8/24/russia-accuses-ukraine-of-attacking-nuclear-plant-causing-a-fire?traffic_source=rss",
         "description": "No increase in radiation levels detected after drone strikes, Russian officials say on Ukraine's Independence Day.",
-        "pubDate": "2025-08-24T12:48:27",
+        "pubDate": "2025-08-24T12:48:27Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Israel pounds Gaza City in preparation for planned offensive",
         "link": "https://www.bbc.com/news/articles/cvg478y8l09o?at_medium=RSS&at_campaign=rss",
         "description": "Sixty-four people were killed in Israeli attacks across Gaza in the past 24 hours, the territory's Hamas-run health ministry said.",
-        "pubDate": "2025-08-24T12:18:44",
+        "pubDate": "2025-08-24T12:18:44Z",
         "source": "bbc.com"
       },
       {
         "title": "After the Taliban cut Afghan drug production, new suppliers emerge",
         "link": "https://www.aljazeera.com/video/project-force-2/2025/8/24/after-the-taliban-cut-afghan-drug-production-new-suppliers-emerge?traffic_source=rss",
         "description": "In this episode, @alexgatopoulos examines developments in a trade that helps fuel wars around the globe",
-        "pubDate": "2025-08-24T12:08:40",
+        "pubDate": "2025-08-24T12:08:40Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Hadeel & Abdelrahman in Gaza",
         "link": "https://www.aljazeera.com/video/on-the-ground/2025/8/24/hadeel-abdelrahman-in-gaza?traffic_source=rss",
         "description": "A video diary for Al Jazeera",
-        "pubDate": "2025-08-24T12:05:45",
+        "pubDate": "2025-08-24T12:05:45Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Cutting Russia off from the web",
         "link": "https://www.aljazeera.com/video/digital-dilemma/2025/8/24/cutting-russia-off-from-the-web?traffic_source=rss",
         "description": "In this episode, @MissSamJohnson looks at how Russia has been whittling away its citizens online freedoms",
-        "pubDate": "2025-08-24T11:59:27",
+        "pubDate": "2025-08-24T11:59:27Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Bangladesh holds international conference on Rohingya: Here’s what to know",
         "link": "https://www.aljazeera.com/news/2025/8/24/bangladesh-holds-international-conference-on-rohingya-heres-what-to-know?traffic_source=rss",
         "description": "Two-day meeting gives a glimmer of hope for the Rohingya refugees forced to flee Myanmar crackdown in 2017.",
-        "pubDate": "2025-08-24T11:58:52",
+        "pubDate": "2025-08-24T11:58:52Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Anti-refugee protesters in the UK rally against hotels for asylum seekers",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/anti-refugee-protesters-in-the-uk-rally-against-hotels-for-asylum-seekers?traffic_source=rss",
         "description": "Far-right protesters and anti-racism campaigners have faced off at rallies across the UK against hotels housing asylum",
-        "pubDate": "2025-08-24T11:57:54",
+        "pubDate": "2025-08-24T11:57:54Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Protesters rally across Australian cities to demand end to Gaza genocide",
         "link": "https://www.aljazeera.com/gallery/2025/8/24/protesters-rally-across-australian-cities-to-demand-end-to-gaza-genocide?traffic_source=rss",
         "description": "Australians join nationwide rallies for Palestine after statehood recognition strains ties with Israel.",
-        "pubDate": "2025-08-24T11:56:57",
+        "pubDate": "2025-08-24T11:56:57Z",
         "source": "aljazeera.com"
       },
       {
         "title": "How Ukraine and Russia will view Trump's attempts to broker a peace deal",
         "link": "https://www.npr.org/2025/08/24/nx-s1-5509676/how-ukraine-and-russia-will-view-trumps-attempts-to-broker-a-peace-deal",
         "description": "NPR's Ayesha Rascoe speaks to Yaroslav Trofimov from the Wall Street Journal about how President Trump's attempts to end the war in Ukraine will be viewed in Moscow and Kyiv.",
-        "pubDate": "2025-08-24T11:55:01",
+        "pubDate": "2025-08-24T11:55:01Z",
         "source": "npr.org"
       },
       {
         "title": "Little legs, big dreams: More than 100 teams compete in Lithuania’s international Corgi race - AP News",
         "link": "https://news.google.com/rss/articles/CBMimAFBVV95cUxQYW9QMk9xcGQ3TUxITVVxVHpiazJ2aExSZTJOT0FpRnNVVXgzMjdDTDNEcWVaNjdydzF5LVdMbnR6cHJaOGtoaXlsUllrcl9rbkUxLTh2TVZGV2U3Z0R1YnNnVHM2bF9Jc0RJSUhJaWladkZ1dVZCdkhXMFQzTFF3c1cxTU5HRnZkbjZ0VUhQMlpnRHQ4OFJCVA?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T11:47:00",
+        "pubDate": "2025-08-24T11:47:00Z",
         "source": "news.google.com"
       },
       {
         "title": "There is something worse than starvation in Gaza",
         "link": "https://www.aljazeera.com/opinions/2025/8/24/there-is-something-worse-than-starvation-in-gaza?traffic_source=rss",
         "description": "It is Israel killing hope with its ceasefire negotiations games.",
-        "pubDate": "2025-08-24T11:24:06",
+        "pubDate": "2025-08-24T11:24:06Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Watch: Solar-powered cars start epic Australian outback race",
         "link": "https://www.bbc.com/news/videos/ckgd7r2mrl2o?at_medium=RSS&at_campaign=rss",
         "description": "Thirty-four teams from all over the world are competing to win the 2025 Bridgestone World Solar Challenge.",
-        "pubDate": "2025-08-24T10:39:23",
+        "pubDate": "2025-08-24T10:39:23Z",
         "source": "bbc.com"
       },
       {
         "title": "Al Jazeera films in Gaza’s empty warehouse as Israeli-made famine deepens",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/al-jazeera-films-in-gazas-empty-warehouse-as-israeli-made-famine-deepens?traffic_source=rss",
         "description": "Al Jazeera's Ibrahim al-Khalili reports from inside the empty main UNRWA warehouse in Gaza City.",
-        "pubDate": "2025-08-24T10:25:48",
+        "pubDate": "2025-08-24T10:25:48Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Did Israel know over 80 percent of those it killed in Gaza were civilians?",
         "link": "https://www.aljazeera.com/news/2025/8/24/did-israel-know-over-80-percent-of-those-it-killed-in-gaza-were-civilians?traffic_source=rss",
         "description": "A leaked military report suggests only 17 percent of those killed in Gaza were fighters.",
-        "pubDate": "2025-08-24T10:00:51",
+        "pubDate": "2025-08-24T10:00:51Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Israeli military uproots thousands of Palestinian olive trees in West Bank",
         "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/israeli-military-uproots-thousands-of-palestinian-olive-trees-in-west-bank-2?traffic_source=rss",
         "description": "The Israeli army has uprooted 3,000 olive trees, citing security concerns, in the village of al-Mughayyir.",
-        "pubDate": "2025-08-24T09:57:31",
+        "pubDate": "2025-08-24T09:57:31Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Turkish first lady urges Melania Trump to speak out for Gaza’s children",
         "link": "https://www.aljazeera.com/news/2025/8/24/turkish-first-lady-urges-melania-trump-to-speak-out-for-gazas-children?traffic_source=rss",
         "description": "Emine Erdogan writes to Melania Trump after the US first lady's letter to Putin about children in Ukraine and Russia.",
-        "pubDate": "2025-08-24T09:42:44",
+        "pubDate": "2025-08-24T09:42:44Z",
         "source": "aljazeera.com"
       },
       {
         "title": "Newcastle vs Liverpool: Premier League – team news, start time and lineups",
         "link": "https://www.aljazeera.com/sports/2025/8/24/newcastle-vs-liverpool-premier-league-teams-start-lineups?traffic_source=rss",
         "description": "Liverpool arrive in Newcastle eyeing three Premier League points and the home side's wantaway striker Alexander Isak.",
-        "pubDate": "2025-08-24T09:23:19",
-        "source": "aljazeera.com"
-      },
-      {
-        "title": "Week in Pictures: From Israeli-made famine in Gaza to wildfires in Spain",
-        "link": "https://www.aljazeera.com/gallery/2025/8/24/week-in-pictures-from-forced-malnutrition-in-gaza-to-wildfires-in-spain?traffic_source=rss",
-        "description": "A global roundup of some of last week’s events.",
-        "pubDate": "2025-08-24T09:09:35",
+        "pubDate": "2025-08-24T09:23:19Z",
         "source": "aljazeera.com"
       },
       {
         "title": "My trip to North Korea's 'Benidorm' - flanked by guards and full of rules",
         "link": "https://www.bbc.com/news/articles/c707d1ez0kno?at_medium=RSS&at_campaign=rss",
         "description": "Anastasia, one of the first Russian visitors to North Korea's new resort, tells of \"immaculate\" beaches, meaty meals and strict rules.",
-        "pubDate": "2025-08-24T07:36:33",
+        "pubDate": "2025-08-24T07:36:33Z",
         "source": "bbc.com"
       },
       {
         "title": "Tropical Storm Fernand forms in the Atlantic Ocean, heads over open waters - AP News",
         "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxQcUxJZmtRQ0VIUFdsZ0d0YnY3dklUTzRqVEtsX3VjdU5qaHdkUzM5WmxjcTlSeGE3QVJoUXNMQV9fZDBHZTZ5ai1sbzVOYXRSYk40TzlGeXJnSkZfRFNzTk1HQ0FEZzhySzR0d1lBLWdZdDVrOV9JRXpfdklqN0pOQUFNOFNQZUMtNWc?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T02:38:00",
+        "pubDate": "2025-08-24T02:38:00Z",
         "source": "news.google.com"
       },
       {
         "title": "South Africa’s most vulnerable struggle to find HIV medication after US aid cuts - AP News",
         "link": "https://news.google.com/rss/articles/CBMinwFBVV95cUxQUjRhNjQ0SFhLaXo5bXMwRVlySnNKSXJ1QzR5ZDRhMlFOMVpUVUdzV253TXJaU3lneWIydkt4NFZibkpHdnB2VXVrUE1KN2NSeG9jTU5rNVZCTVpVRFJ2aU9Da0NiMFhNaEJfVHdoY2MwUTdqcm9FY1FvYlZoSzM3ZXVFeHNweW9pY0JGcFJ4TmkwaUotYXpoVzJ0ZkhRS28?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T02:13:00",
+        "pubDate": "2025-08-24T02:13:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Venezuelans respond to Maduro’s call to enlist as US warships move toward Caribbean - AP News",
         "link": "https://news.google.com/rss/articles/CBMiywFBVV95cUxONUl6SmdUVDhmMDdWSGxDdXpSZzRHREQwMmFGM19WcTNHcVZIZ0VCQTBSTVlvQ1VGS0txUFM1aEZzcUxncHo4ODhJeWVMNEhuOFhscGNaWVFxMWxnX1JKUXJyRnN5Ymt3OVo5Z2R3ZW5OaVhHaDZPdmdDdEtZc2lpcWJHODFuSjhXMmdWdW9NM0N3bUxVVzBDQVBPbFZqZ1laeFpGbGk4R3psOTVuSHNYUFZGeDl0eU10cmVVcnpoNDlMWno4dzBRd2ZXRQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T00:48:00",
+        "pubDate": "2025-08-24T00:48:00Z",
         "source": "news.google.com"
       },
       {
         "title": "North Korean leader oversees new missile test, state media says",
         "link": "https://www.bbc.com/news/articles/cj3lp47nxdjo?at_medium=RSS&at_campaign=rss",
         "description": "Two new air defence missiles with \"superior combat capability\" have been fired in a test observed by Kim Jong Un.",
-        "pubDate": "2025-08-23T23:51:33",
+        "pubDate": "2025-08-23T23:51:33Z",
         "source": "bbc.com"
       },
       {
         "title": "Photo highlights from the rhythmic gymnastics World Championships in Brazil - AP News",
         "link": "https://news.google.com/rss/articles/CBMiuwFBVV95cUxOMmZkcVZaR2E2SWNhWWhxYTB2OFRrZ1pmNFhQeVlpYnhlUVZLaksxY0lJUzVJaGJHVDdHNTNESkdWN0dTZ3dRX0l4UF9qWmVFbHo1UnNjaDBSajJNSks4SGQwWkhtcEpZOVctUF9oZFpWNjJPSkUwNkZhWnRFM0hKeWNzc1NGdzJlTHliQWc0VzdkU1lWZDZLRXg4OEY3MWVGcElybUFhRWx4U2FtQThrOVBXdGNJeDdnV2Nn?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T23:31:00",
+        "pubDate": "2025-08-23T23:31:00Z",
         "source": "news.google.com"
       },
       {
         "title": "For orca left in limbo, zoo resorts to sexual stimulation to stop inbreeding",
         "link": "https://www.bbc.com/news/articles/cedvp89jy4do?at_medium=RSS&at_campaign=rss",
         "description": "Wikie, 24, and her 11-year-old son Keijo still don't have a new home despite months of wrangling.",
-        "pubDate": "2025-08-23T23:09:04",
+        "pubDate": "2025-08-23T23:09:04Z",
         "source": "bbc.com"
       },
       {
         "title": "Nevada to face Taiwan in the Little League World Series final - AP News",
         "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxNOXlYSFcxQ2FzVFVkOUgyZ2ZvN1oyUDdvRjJLSnZ5Q09tWGZPTWZGb0RfZ1lBMEx3N0pyeFVkWHh6MmRycEpOdUN5dnVma2lLRUwtME94MWFsNF80Sk9jTzdaVDZkRE9UZlp3YjBhdUVDV2FwSzNOdENDeDlTVEtoRGQ2V05relJod0tGakVZZE1uanlmVHh4N1Jhdk8?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T22:35:00",
+        "pubDate": "2025-08-23T22:35:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Boxed in by shifting tariff rules, European shippers pause some U.S.-bound parcels",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5513936/dhl-parcel-tariffs",
         "description": "New customs regulations take effect August 29, and many European postal agencies and companies say until new systems are set up they can't ship some goods. Gifts worth less than $100 are not affected.",
-        "pubDate": "2025-08-23T22:21:20",
+        "pubDate": "2025-08-23T22:21:20Z",
         "source": "npr.org"
       },
       {
         "title": "UK's Chagos Islands deal 'significant victory', says Pope",
         "link": "https://www.bbc.com/news/articles/cx2p1k1r2glo?at_medium=RSS&at_campaign=rss",
         "description": "Pope Leo XIV said he hoped Mauritian authorities would ensure the refugees are able to return home.",
-        "pubDate": "2025-08-23T21:35:11",
+        "pubDate": "2025-08-23T21:35:11Z",
         "source": "bbc.com"
       },
       {
         "title": "High stakes diplomacy and canceled Halibut Olympia, insights from the Alaska Summit",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5508462/high-stakes-diplomacy-and-canceled-halibut-olympia-insights-from-the-alaska-summit",
         "description": "NPR's Mary Louise Kelly, who has covered her share of high stakes diplomatic meetings between some of the world's most powerful people, spoke with Scott Detrow about what was different during the recent Trump-Putin Alaska Summit.",
-        "pubDate": "2025-08-23T21:20:14",
+        "pubDate": "2025-08-23T21:20:14Z",
         "source": "npr.org"
       },
       {
         "title": "How do Scottish honesty boxes work and who uses them?",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5508452/how-do-scottish-honesty-boxes-work-and-who-uses-them",
         "description": "The Kitchen Sisters production team takes a look into the long held Scottish tradition of honesty boxes - where you leave the money in the box and take what you need.",
-        "pubDate": "2025-08-23T21:20:12",
+        "pubDate": "2025-08-23T21:20:12Z",
         "source": "npr.org"
       },
       {
         "title": "The looming battle for Gaza City",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5509585/the-looming-battle-for-gaza-city",
         "description": "As Israel prepares for another major military offensive in Gaza, a new report says Gaza is in the grip of a full-blown famine. Will Israel accept a ceasefire deal or attack Gaza's biggest urban hub?",
-        "pubDate": "2025-08-23T21:17:17",
+        "pubDate": "2025-08-23T21:17:17Z",
         "source": "npr.org"
       },
       {
         "title": "Turkish first lady appeals to Melania Trump over Gaza children",
         "link": "https://www.bbc.com/news/articles/cn47ppy382wo?at_medium=RSS&at_campaign=rss",
         "description": "In a letter, Turkey's first lady asks Mrs Trump to appeal to Israel to end the war in Gaza.",
-        "pubDate": "2025-08-23T21:13:56",
+        "pubDate": "2025-08-23T21:13:56Z",
         "source": "bbc.com"
       }
     ],
@@ -358,351 +358,351 @@
         "title": "Pub and travel bans proposed under sentencing rule changes",
         "link": "https://www.bbc.com/news/articles/c5ypej14j2xo?at_medium=RSS&at_campaign=rss",
         "description": "Ministers say the reforms are aimed at reducing reoffending and easing pressures on crowded prisons.",
-        "pubDate": "2025-08-24T16:17:49",
+        "pubDate": "2025-08-24T16:17:49Z",
         "source": "bbc.com"
       },
       {
         "title": "Government plans to overhaul asylum appeals system",
         "link": "https://www.bbc.com/news/articles/cg4xp4ywk47o?at_medium=RSS&at_campaign=rss",
         "description": "The government would establish a new and independent body, with the aim of hearing cases more quickly.",
-        "pubDate": "2025-08-24T16:01:58",
+        "pubDate": "2025-08-24T16:01:58Z",
         "source": "bbc.com"
       },
       {
         "title": "At least 1 dead in Moscow shopping center explosion, 3 injured - AP News",
         "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxQTkFSV1FmWi1hZkZ0X2l3V3R1MjV5LU1VWXJ1ZXpYRndhUTVLRUdRQkpRTl93RjRxY0F4S0ZTelF4NmFKVDZGOTJNdTFyaWd1ZEdnWlhkNGdzZ1Yxdy11eEhVRF83bURNaUwyQUFlbjlhcXBsYnY5MVNWUVdyNWlJYTlzN3EzbGVVM1BndGpfaFJ0STlOWWV4NExWaFg?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T12:27:00",
+        "pubDate": "2025-08-24T12:27:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Politics chat: FBI searches John Bolton's home, National Guard in Chicago?",
         "link": "https://www.npr.org/2025/08/24/nx-s1-5508934/politics-chat-fbi-searches-john-boltons-home-national-guard-in-chicago",
         "description": "We discuss the latest political news, including the FBI search of former Trump adviser John Bolton's home and whether President Trump will send National Guard troops to more cities.",
-        "pubDate": "2025-08-24T11:54:57",
+        "pubDate": "2025-08-24T11:54:57Z",
         "source": "npr.org"
       },
       {
         "title": "Smithsonian artists and scholars respond to White House list of objectionable art",
         "link": "https://www.npr.org/2025/08/24/nx-s1-5511241/smithsonian-white-house-art",
         "description": "A page published by the White House entitled \"President Trump Is Right About the Smithsonian\" lists exhibits, educational sites and more that the administration seems to take issue with.",
-        "pubDate": "2025-08-24T09:07:29",
+        "pubDate": "2025-08-24T09:07:29Z",
         "source": "npr.org"
       },
       {
         "title": "Clarkson for PM, attacks on police dogs: Do Parliament petitions make a difference?",
         "link": "https://www.bbc.com/news/articles/cg4xqn91rwlo?at_medium=RSS&at_campaign=rss",
         "description": "People love signing petitions to get issues they care about debated by MPs - but some can't resist having a laugh.",
-        "pubDate": "2025-08-23T23:40:38",
+        "pubDate": "2025-08-23T23:40:38Z",
         "source": "bbc.com"
       },
       {
         "title": "US seeks to deport Kilmar Abrego Garcia to Uganda after he refused plea offer in his smuggling case - AP News",
         "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxOeXREMHZ6RlM3M1k5Qk5IeFZKQ2FQZDBBcDhGZWsyVTc2ajV0Zi1aaVpLc1J1cVhHNWhiVzBCMXhvcEV2ZkFXcWtaNHhVYXZRYWJGNmlwTDhyWFBrUU1yMmxWQnNVdUw2ajI1ZHZ2NzN2S0ZnUjJJRGtrT2dqZEZXdkVSWnVaLV9RTEtJV0trSnVDTTU0a1l5SW9ibzROeFJfTU9oLUZR?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T20:02:00",
+        "pubDate": "2025-08-23T20:02:00Z",
         "source": "news.google.com"
       },
       {
         "title": "It's been a busy week at the Justice Department. Here's a recap",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5511436/its-been-a-busy-week-at-the-justice-department-heres-a-recap",
         "description": "The Department of Justice has been in the news all week, both over its handling of the Epstein investigation and its search of a home of Trump's former national security adviser.",
-        "pubDate": "2025-08-23T11:47:57",
+        "pubDate": "2025-08-23T11:47:57Z",
         "source": "npr.org"
       },
       {
         "title": "A former federal prosecutor reviews legal options against assertive presidential power",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5511330/a-former-federal-prosecutor-reviews-legal-options-against-assertive-presidential-power",
         "description": "NPR's Scott Simon talks with Politico's Ankush Khardori about what legal checks remain as the Trump administration flexes presidential power.",
-        "pubDate": "2025-08-23T11:47:53",
+        "pubDate": "2025-08-23T11:47:53Z",
         "source": "npr.org"
       },
       {
         "title": "Week in Politics: Trump and Putin; possible rate cuts; lawmakers and redistricting",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5509911/week-in-politics-trump-and-putin-possible-rate-cuts-lawmakers-and-redistricting",
         "description": "We discuss the latest political developments, including President Trump's crackdown in Wahington, D.C., and redistricting efforts in Texas and California.",
-        "pubDate": "2025-08-23T11:47:38",
+        "pubDate": "2025-08-23T11:47:38Z",
         "source": "npr.org"
       },
       {
         "title": "What's the Canadian movement known as 'elbows up' and its link to tariffs?",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5507154/whats-the-canadian-movement-known-as-elbows-up-and-its-link-to-tariffs",
         "description": "NPR's Scott Simon speaks with Donna Noade Reardon, mayor of St. John, New Brunswick, about how President Trump's tariffs have affected her province as well as Canada's relationship with the U.S.",
-        "pubDate": "2025-08-23T11:47:28",
+        "pubDate": "2025-08-23T11:47:28Z",
         "source": "npr.org"
       },
       {
         "title": "Trump makes over the Rose Garden, Mar-a-Lago style",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5509554/rose-garden-paved",
         "description": "Trump has swapped out the grass in the Rose Garden with stone, turning what had been a lawn into a patio that bears a striking resemblance to one at his Mar-a-Lago resort in Palm Beach, Fla.",
-        "pubDate": "2025-08-23T09:00:00",
+        "pubDate": "2025-08-23T09:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "Farage vows mass deportations to tackle small boats",
         "link": "https://www.bbc.com/news/articles/c9vd3rx33g1o?at_medium=RSS&at_campaign=rss",
         "description": "Plans outlined by the Reform UK leader would see the country taken out of the European Convention on Human Rights.",
-        "pubDate": "2025-08-23T08:38:04",
+        "pubDate": "2025-08-23T08:38:04Z",
         "source": "bbc.com"
       },
       {
         "title": "Congo’s prosecutor asks for the death penalty for former President Kabila for war crimes - AP News",
         "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxPSHJSWF9KWlo1VmlaVVJxS05scVhpblhTNEp6cTFDU3d0ZEFBSnRwU1dEbEpxMzV1SjlEaThMcWZObXRsV1RzdENraXp4bXFoUUYtTG1hckVRYWNvajhKSnJjdmFrY1FVZ0lJbWpsT2pCcmlURW5GRXVORDhWMFE4NWZLcC1aYlRqeTNZb1VUOA?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T08:27:00",
+        "pubDate": "2025-08-23T08:27:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Photos from the Texas Legislature as Republicans push for new political maps - AP News",
         "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxOU0YyMnZMVnNiRmlsVmtKY0JkX3UwbkFMRjVRWFlWMTZMdFhabFRrV21NSVRlbWxaWEZqZVZSVVJ6MXBNRkNnTEVOZnMxZVdMbW1UejVRVEdoN2llN09la0FiZVBhS200SjFVeWJNR2RfUlZkNFRuVk1USE1SYm14MjVNRXlKSjBsNW1YVncyM3FkbUhOVzdmeW9pMEkyRnZOMHlVX2ZNSkRBUjEzRGVUY052Zlg?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T07:17:00",
+        "pubDate": "2025-08-23T07:17:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Female political prisoners in Belarus face abuse, humiliation and threats of losing parental rights - AP News",
         "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxNZHRuZXVJY1lQZ0hYMFd0X2VqOUxlXzN3UF9oSlJqaXlMTW5pSk9Id2lOSHJWeW9Jc0ZlQUtZM2ltaDVIOHVRZkdlbGtteV9wX0JUX2RuZzRFUm1JQmpHT2RQT19IWjRQWG03cTNpbEc1ZVRoZUZSbFBQRlE0eENFTHFwUHBuNDdQUERfMzVWdkZuVnFHeTlkRFZpaVp2VlVsRmM5ZXY3RFV2WHljWUo3MTd5aHo?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T05:01:00",
+        "pubDate": "2025-08-23T05:01:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Police notified after neon green sex toy thrown onto field during Titans preseason game - AP News",
         "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxObmdVbjN3cjZ6Qlo1NzZKcW1DWHBGOXBSWWwtQzJEa2I5TTdMWXUwMjZpRTlqUXNSbnBUWXZGdnJUMFdpY3JRU1U4aFJEZzZOd2xubk8tSXZ0eTR2RDF1dG1yYU5PVVhwRlVfZ19qZXJPUlVpSVNZMFVYRmY0QWI4OXdDc1pCa0ZrYTl5a29ia1FkRTA?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T04:02:00",
+        "pubDate": "2025-08-23T04:02:00Z",
         "source": "news.google.com"
       },
       {
         "title": "North Korea accuses South of ‘serious provocation’ over border warning shots - AP News",
         "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxQSFlCUkhnTVBCZW85YWNqLWtxb0VZcTUyODZRa3ZJZXdEVzdtazQzdzZtNVhXTEZwMW9FaDV2ODZ1QUk4QnQtRkZPclh2bVMxUDFlSTZieVlaYW4xVzBqNERGdkI2aGpmcS1HVnlhZnJ6S09kdzZPeXNRSE40ZHZxcVQ0bGV5c1B4aHc5VHAwck4xekZ3bWNwRTlaazJ5TzlpS1RJb3A1dy1aQVU?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T01:34:00",
+        "pubDate": "2025-08-23T01:34:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Are young women more left wing than men - and, if so, why?",
         "link": "https://www.bbc.com/news/articles/cqxg89jzvl1o?at_medium=RSS&at_campaign=rss",
         "description": "A divide appears to be opening up between young women and young men in the way they vote and view the world.",
-        "pubDate": "2025-08-22T23:48:35",
+        "pubDate": "2025-08-22T23:48:35Z",
         "source": "bbc.com"
       },
       {
         "title": "California’s long-delayed bullet train slated to run in the Central Valley by 2032, report says - AP News",
         "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxPZHNLcWRfRVQ5YmNzYWViLURJcnhkdEptWXJiWXc3aTRhX2Z4SUNRaFFSZUlNR0w4cU5NZHFpOUtjRXNVQTk3bWxwQm4tR2hzTk9wd19tVXBCamJhWlVqelM2cXktdTIzTU4yX1lxOWhzaExmTGpwanAzSUtuTWZESVNRODBTMXN5YTUzS1JKUQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T22:57:00",
+        "pubDate": "2025-08-22T22:57:00Z",
         "source": "news.google.com"
       },
       {
         "title": "El Salvador is enforcing strict student dress codes to bring discipline back to schools - AP News",
         "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxQZm5iVU1kclBPQjFsckxvTGhvNXl4UjZYcEF6YkdOampScTZOb25ZcTl6MVpKLWFmV3ZCdmZoUWVWT3FnQTlvTGVXSEtLVGd2Mkxlb1hIRXh6OFFBZVZLMFJVaUY4SjNMd3Y1cjdoeU9KWTZ1VF9NTlpnRHhxdnd6U0lNTlpVa1pOQ0NUa3EtcEd3TWNEakMwNEtGSQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T22:44:00",
+        "pubDate": "2025-08-22T22:44:00Z",
+        "source": "news.google.com"
+      },
+      {
+        "title": "North Carolina Supreme Court says bars’ COVID-19 lawsuits can continue - AP News",
+        "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxQTUlMZHhIR015Vlp6SVNwXzdZai1FT1dRR3VnVEFsWlNTaWpYYzIweW9WNUJjV3pJRFY5MWlGdXp0YVJINVZHdldMMjBTX2xnVHpiWlZaZXVkTXlXMHNnU281OVlmZGNfdjRHOTNSVWxCZW1fUU9xUl9DbVBUWVdRSUZNOTlBeHhKRXRpZE5qRGxVc2VuRkoxVHlPdnlmVUtvLUNKbkdMS19TeDFHbjV2YkJxZmk?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T21:56:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Former UUP MP Rev Martin Smyth dies aged 94",
         "link": "https://www.bbc.com/news/articles/cde3p2450nwo?at_medium=RSS&at_campaign=rss",
         "description": "As well as representing Belfast South in parliament, he served as the Grand Master of the Orange Lodge at the height of the Troubles.",
-        "pubDate": "2025-08-22T21:54:12",
+        "pubDate": "2025-08-22T21:54:12Z",
         "source": "bbc.com"
       },
       {
         "title": "Wisconsin judge rejects motions to dismiss charges against Trump aides - AP News",
         "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxQTjR3LU93MFowSFN3ektYekhQVk1JQ2pHYnhjdm80Rmo4Ty1NYlEtN1lGZHNUN0VaM1pPVGZtQXdZTm1laGR0MG5kWlBzeGxSVFlPNFRTMkVJVVZYWTFjaTZZS2VnTElvYlFBQ1Z3enFLNjJzUTREOHBtLUVRMi1TczZCQnJjd0R2ZndfbkRXbGJXcndwd0pMUHRBZjkyM3dZV1RHVnZB?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T21:51:00",
+        "pubDate": "2025-08-22T21:51:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Maria Sharapova, Bryan brothers to be inducted into Tennis Hall of Fame - AP News",
         "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxPQTV1UC12VlFPSjYtMWJmaTFKVGR2ZnRJTnB0QXFuRGFSeDhDMWV5cUVZYVdSTG12Y2MyU2N2NWgySTd4QWpHTkxiMk1MX2JaWDRDOFI2ZUJYTkhRcFZhaEo3eXYxSHAtc1FDVWVTU195YWc4RE1mWXQyTW5sd0VaU09pSXZXbWIwaVVwMHd0MTF5Nzg0UjFnUExFUFo0NFJURHdoUWQ5WnI1M0RkNDl3?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T21:24:00",
+        "pubDate": "2025-08-22T21:24:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Coco Gauff hires Aryna Sabalenka's former serving coach, Gavin MacMillan, before the US Open - AP News",
         "link": "https://news.google.com/rss/articles/CBMiqgFBVV95cUxQMzI5MUIxVWVKYjF1YUpHX1d3VnZNUGFNTDJXWV9oX1JKelFMaXMxM3FWemxrUGpGdDhQaXlFTVVtZFluUEdPUkNEQlNoX2JGczA4U0lRRkx0N2xhb1dueDVzTnFtWmZUUVhwdzAwQlMyRnl4Y3BlanhnakRTa0ZyeExrYTJ4cGNPZWRMdDRfTEtMQWdvSlE0WW5EZ1RzdzB0d25jZHN3RTVtQQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T20:26:00",
+        "pubDate": "2025-08-22T20:26:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Intel will give the U.S. government a 10% stake, Trump says",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5509673/trump-says-us-government-will-take-stake-intel",
         "description": "The president's highly unusual announcement underscores the Trump administration's desire to take control over U.S. businesses.",
-        "pubDate": "2025-08-22T20:17:14",
+        "pubDate": "2025-08-22T20:17:14Z",
         "source": "npr.org"
       },
       {
         "title": "Texas and California advance in their reshaping of the national political landscape",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5508870/texas-and-california-advance-in-their-reshaping-of-the-national-political-landscape",
         "description": "President Trump initiated a redistricting arms race when he urged Texas to redraw its congressional map to boost Republicans. It's part of a broader trend of Trump pushing the limits of democracy when it comes to consolidating power.",
-        "pubDate": "2025-08-22T20:03:06",
+        "pubDate": "2025-08-22T20:03:06Z",
         "source": "npr.org"
       },
       {
         "title": "Justice Department releases transcripts from its conversations with Ghislaine Maxwell",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5494553/epstein-maxwell-doj-interview-transcripts",
         "description": "Maxwell spoke with top DOJ officials over the course of two days in late July. Asked about President Trump, she said she had never witnessed him \"in any inappropriate setting in any way.\"",
-        "pubDate": "2025-08-22T19:40:40",
+        "pubDate": "2025-08-22T19:40:40Z",
         "source": "npr.org"
       },
       {
         "title": "Rockies release struggling pitcher Austin Gomber, a big piece in the Nolan Arenado trade in 2021 - AP News",
         "link": "https://news.google.com/rss/articles/CBMijgFBVV95cUxNQmh4dEdwLWlBOGliUnBoUFRicjd6Q2ZZTFZsM2FLaG1YcnJoM0hlNG9IMW4yVDJFa1psTURyckRoM3JlWGxqaEthTklNWnF5UkJ0MTZ5Q0J2UlFySFJDaVVzVVVrMTdETzRZb1EzeVlWdXVqVmZLbmtieUp0VUg2TjI0MjNKNjAwVTh5SFFR?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T19:24:00",
+        "pubDate": "2025-08-22T19:24:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Home Office seeks to appeal against court ruling on asylum hotel",
         "link": "https://www.bbc.com/news/articles/cy5p2ye95z9o?at_medium=RSS&at_campaign=rss",
         "description": "The High Court refused a last-minute request by the Home Office to intervene in the Epping asylum hotel case.",
-        "pubDate": "2025-08-22T18:15:24",
+        "pubDate": "2025-08-22T18:15:24Z",
         "source": "bbc.com"
       },
       {
         "title": "Kurdish political figure arrested in Iraq, sparking clashes that leave 5 dead - AP News",
         "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxQVk84RE0yMTRyaGduZmgyeWdqYTdfaDBqUlBuelRtUEFHT0Q4REdVZHZkUVpneWRRMmdhT3FkWGhsWFMyVzZ6elJmbnRiS1FQMG5ZTWt3RV9xc2VIc195OUNWLWRobEN3Vi02UUZnY29VMzZBb3phTzRaeUQzazFuOVVpVnhZNFlkRUl6Q2hrem1tQU9IejVmV3YyeVYybXJFVWVkcTdxVUtMSm5mcXJ0YkhxYw?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T17:24:00",
+        "pubDate": "2025-08-22T17:24:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Business magnate Lord Swraj Paul dies aged 94",
         "link": "https://www.bbc.com/news/articles/c0r72nj11kzo?at_medium=RSS&at_campaign=rss",
         "description": "Lord Paul had been deputy speaker of the House of Lords and chancellor of Wolverhampton university.",
-        "pubDate": "2025-08-22T16:44:30",
+        "pubDate": "2025-08-22T16:44:30Z",
         "source": "bbc.com"
       },
       {
         "title": "Trump embraces tough-on-crime mantra amid DC takeover as he and Democrats claim political wins - AP News",
         "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxQYno2QXpad0R3Y0dYM1NtWVB2VVpjMUNtbVVjclJyQUVTWTAtNmJBT3pIcUVPNTZPSjRsdHJLbVdJenNYYkhrbkJscUViZTVNNzFOWVQxOFZrbGNVY1o3YVJCZXpaQlRENjl4cW9pZk1qUk03cGZxUS1tdWo1X3c1bW51d1FDWFRUVkR6VXpPMXBwNnlJN3ZJZHZ4Vml6bXFueTZQTE45NUtTT3FFNjl0bjdHYw?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T16:33:00",
+        "pubDate": "2025-08-22T16:33:00Z",
         "source": "news.google.com"
       },
       {
         "title": "What are Rachel Reeves' options on property tax?",
         "link": "https://www.bbc.com/news/articles/cm2k1m56xgjo?at_medium=RSS&at_campaign=rss",
         "description": "Reports suggest the government is considering shaking up the property tax system to raise revenue.",
-        "pubDate": "2025-08-22T15:28:19",
+        "pubDate": "2025-08-22T15:28:19Z",
         "source": "bbc.com"
       },
       {
         "title": "What to know about China’s new regulations on rare earths - AP News",
         "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxNMG5SeWR3VFRKU1lJcmphd0QzNVhOeFZmTjg1TFp3RkY1c3Ixd1BFMmhsa3lxbXMzSTcxaDM2WlQ4bXVfZWlsaUdxRFMyZlBHTXVPQjVTQXVqdWFnTlpfQ0hLSXFGZTY2Wk04MEh4UTAzWHNfVkNjZmRGSERmcWo5QmxNVTZSelZPbHdzQ0gtdHotT2lYcHpj?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T12:30:00",
+        "pubDate": "2025-08-22T12:30:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Six new members join Reform UK's party board",
         "link": "https://www.bbc.com/news/articles/cx291knwl3yo?at_medium=RSS&at_campaign=rss",
         "description": "The decision-making committee welcomes Dame Andrea Jenkyns and three elected members to its ranks.",
-        "pubDate": "2025-08-22T12:27:23",
+        "pubDate": "2025-08-22T12:27:23Z",
         "source": "bbc.com"
       },
       {
         "title": "Ngidi’s 5-wicket haul leads South Africa to series-clinching win against Australia - AP News",
         "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxQN0JTS0R6LU05MzlZQ1M2OHVlZXQwYnJXVXdyVlF2bXRmRXh2OWdTMFc4VngxMjYwVTA2bkZzQXAwZlVic3NnOHh4ZzdsUk1pa21TdllDaG9Id2MwcWlid3AwYUQta0RMaG5Jal9IWEs0UWpiaXNOU2hjM3loSFVqN3B6NXJSdVREaS13Tllydw?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T12:17:00",
+        "pubDate": "2025-08-22T12:17:00Z",
         "source": "news.google.com"
       },
       {
         "title": "UK's third-largest steelworks collapses into government control",
         "link": "https://www.bbc.com/news/articles/cy0818y4jdlo?at_medium=RSS&at_campaign=rss",
         "description": "Hundreds of Liberty Steel workers in Rotherham and Sheffield face an uncertain future.",
-        "pubDate": "2025-08-22T12:12:21",
+        "pubDate": "2025-08-22T12:12:21Z",
         "source": "bbc.com"
       },
       {
         "title": "MSP Jeremy Balfour resigns from Tories over 'reactionary politics'",
         "link": "https://www.bbc.com/news/articles/c5ylwxwlpx1o?at_medium=RSS&at_campaign=rss",
         "description": "The Lothian representative claims senior MSPs are being ignored under Russell Findlay's leadership.",
-        "pubDate": "2025-08-22T11:46:26",
+        "pubDate": "2025-08-22T11:46:26Z",
         "source": "bbc.com"
       },
       {
         "title": "Child benefit: What is it worth and who can claim it?",
         "link": "https://www.bbc.com/news/articles/c5y3lyq28lgo?at_medium=RSS&at_campaign=rss",
         "description": "There is a limit to the amount you or your partner can earn before you start to lose child benefit.",
-        "pubDate": "2025-08-22T10:00:14",
+        "pubDate": "2025-08-22T10:00:14Z",
         "source": "bbc.com"
       },
       {
         "title": "Thailand's political path is shadowed by the ongoing dramas of former leader Thaksin Shinawatra - AP News",
         "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxNVFVMMFFsMy1KRGtNNnRoZjJOTmlPemV6R2lFZEptWVVmM212c1RoVGlTN1NyOTRjaUI3Nk1CeGdSSXZDRGdGc1A5RjJpU3BYT3JJLTZ4WWlIWi14elBmMzFDNXh1a3JJZGdCS1FjcVNVejl0bTNacW43QnZUTEhKSjlYaDQxZUJtR1Nxc09qZlgtcDRXVW42WlQxdXJNRTFuOE9kRk9MMTdwRXhf?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T06:10:00",
+        "pubDate": "2025-08-22T06:10:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Crackdown on child benefit claims from abroad after £17m saved",
         "link": "https://www.bbc.com/news/articles/cr5r1zpl39jo?at_medium=RSS&at_campaign=rss",
         "description": "The government is expecting the move to save £350m over the next five years, after a successful pilot.",
-        "pubDate": "2025-08-22T06:08:53",
+        "pubDate": "2025-08-22T06:08:53Z",
         "source": "bbc.com"
       },
       {
         "title": "Giants' Jaxson Dart clears concussion protocol after taking a hit in preseason game vs. Patriots - AP News",
         "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxNVHYxUEpKZXJIc3lqSkNoV2RmX1VJOHdWZXJtR00xWm4waGsyTFptUXBZTmp1RW0xdlJlVUltQ3I5TURqaWZFdWVrQmJsbG1kTE43RFgzbl82b2J1VTJSTUdOdUVDZjVJdFRwOXZjemNEczFFdnQ3YV9XaUlORVZXYXlCVE4zYVBEdE9NVGV6Yi0wWDI0YkE?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T04:10:00",
+        "pubDate": "2025-08-22T04:10:00Z",
+        "source": "news.google.com"
+      },
+      {
+        "title": "Trump’s crackdown in DC leaves residents on edge as federal agents set up checkpoints - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxOSUhLZkVzSk1nZ2RUSEoydXRhenZCYUpTUTZIOUtqSWdQMXk3cXNwaW1kN2VzYzZCMWROS3RkM2JtbVZzc1BqVmhSS2ZlbDdLUTl0THg2QnRXUlE0Sng1Mjl0c2NRSXJZOWVOZW1tTXExLXhZTHNSMjJmSGhITC1Sdi1nRElYRHZHMzhOWTFYMzdZa1VPSElNSGRqZ1FsS2FhMWhUSTNTYU54OUlJQU13LWZLTXh3ZGEtSUE?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T00:56:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Brazil's police accuse Bolsonaro of receiving $5 million over 1 year, suspect money laundering - AP News",
         "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxNQWVqeEV4TXZCOTlwMjcwQkxxR3paS0xBMkljT2tFRl9CT3hTN2drSjVGSHZpMUhNa2V4WVRoMkdvLWpPNGYtUkM2TXI0QmxJaEM4dTNlY0ppUjF6ZUVGeWR4bHF3OU9ySU5iX2tDVXVwYmRHeDYzZ25vU0dud3lVcTFkMnJUMDJ6emN0OHB4V2VVOTZtTnpGOV92V1ZuNzNzamVLOVdQdHZxZFFPV1E?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T00:22:00",
+        "pubDate": "2025-08-22T00:22:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Defamation case against Fox News highlights role of its hosts in promoting 2020 election falsehoods - AP News",
         "link": "https://news.google.com/rss/articles/CBMipwFBVV95cUxQMkVrYTNXV25SUUM2a25hTmptZHAwbmZ3MnNJTmRsOUU3c0hxQURwQWI0eWVBN0ZuWDFlWE1fU3J3WW5VVFlZaGluTjFoaXZ4YlBGNmdqcGpjVWlyeHA0Tnlta05DVnB5YnpheC15WmVBekZ6Vmw3RzBhZjNwWnByRVZqS0hFODJOR3RsVDlFeW01SmpMcDNCRUZ3X3l2LS11N1RzSng2aw?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T22:54:00",
+        "pubDate": "2025-08-21T22:54:00Z",
         "source": "news.google.com"
       },
       {
         "title": "US home sales rose in July as mortgage rates eased a bit and home prices grew more slowly - AP News",
         "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxNUFpROUl1T0JGeXZqVWpvRHNOWExWQlBKVTJoVEN2a3pZd1A2YXRQb1dtbEVhQTBJQ3BEeTRkdWROZHlCQ1c0OWVqcmlfckdxd0RQU2pmUkdFUU14YmxmX1RQZW1UQ1pmU20wNkdHcUN4N19YZkFHUnU1N0c5dVlCVzh1cXhqdzBfUkU0ZGU2bjZGWFBQaXhlanU1MXdnZ0pEZHNnRw?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T21:44:00",
+        "pubDate": "2025-08-21T21:44:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Record 111,000 UK asylum applications in past year, figures show",
         "link": "https://www.bbc.com/news/articles/cwy1kxv8xewo?at_medium=RSS&at_campaign=rss",
         "description": "The latest data, which covers Labour's first year in office, also shows the government is processing cases faster.",
-        "pubDate": "2025-08-21T17:41:08",
+        "pubDate": "2025-08-21T17:41:08Z",
         "source": "bbc.com"
       },
       {
         "title": "Volunteers suspend Ruby Whitehorn indefinitely nearly 2 weeks after arrest - AP News",
         "link": "https://news.google.com/rss/articles/CBMiowFBVV95cUxNRkVFTFA0YzdEOF80cWlKRjJpOVZLSmpzSkxDSnFqWVpYQVo3cjhRZWU4YlNVQnpFb01wNXRHb2hTbmNVaXllbldla1BLM3N1RkNfVVJmaXBDUHVoOExtRDVrWkRWU1VBaDdBdDZHWWhtY2oySHh4RkZRSVVYMExkdTk5anl4TVNFcjV2elpCTURXdUdKTGJlT0ZzcGdzTWZNWHdB?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T17:15:00",
+        "pubDate": "2025-08-21T17:15:00Z",
         "source": "news.google.com"
-      },
-      {
-        "title": "Julie Delpy and Suranne Jones explore the personal cost of politics in ‘Hostage’ - AP News",
-        "link": "https://news.google.com/rss/articles/CBMi0gFBVV95cUxNOVNneXl4SWFCQ1BwbnhwOHJUcU42QVQ4MnYzenpkdHByRVQyX1k1OGdySjI2ZUZKODBXaEdRU0Q5OU0yb2t0bzVYWWRIQWlENmt2TTRnOXlaUFhuWkU3UDhOMFZ1ZEZUM2t1OUxnVFRHOHdFazhvanZKOFdpdVBjNnZLZTllbG0xYUo4Uk94aGNQVWxzMVB1UEFHdGlnTi1mR19kTUNxSHp1c2pjeFYyYzVNQUpEQTJRS0pCZ3JrSHRTbzYyZjA4ckhmWDk5SU9leWc?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T17:03:00",
-        "source": "news.google.com"
-      },
-      {
-        "title": "Woman jailed for race hate post released from prison",
-        "link": "https://www.bbc.com/news/articles/c5yl7p4l11po?at_medium=RSS&at_campaign=rss",
-        "description": "Lucy Connolly is released from HMP Peterborough after receiving a 31-month sentence in October.",
-        "pubDate": "2025-08-21T16:57:17",
-        "source": "bbc.com"
       }
     ],
     "Tech": [
@@ -710,351 +710,351 @@
         "title": "Women’s Professional Baseball League launching in 2026 offers new hope for athletes - AP News",
         "link": "https://news.google.com/rss/articles/CBMifEFVX3lxTFBvQ19JemliYTdncnJqVmpycEtqaWNLNEtGYWtYVF8xNVFCUk5STEJ3Wms1NFROeGVpNzhZd045UmtqcXJXckxQb0xUOFF2S05FRHZ0cGYwVVhjSUtrNE4xdEc5RmdGVXFWampkMTFCTm1UNkpPSXRlSXE1WDg?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T23:28:00",
+        "pubDate": "2025-08-23T23:28:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Bubbling questions about the limitations of AI",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5509946/bubbling-questions-about-the-limitations-of-ai",
         "description": "NPR's Scott Detrow speaks with Cal Newport, author and computer science professor at Georgetown, about AI's limitations and if progress within the industry has stalled.",
-        "pubDate": "2025-08-23T21:20:20",
+        "pubDate": "2025-08-23T21:20:20Z",
         "source": "npr.org"
       },
       {
         "title": "What to know about visas for foreign truckers and the politics of a deadly Florida crash - AP News",
         "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxPbFVSNk90UUF6bTZlM0xSV09aZUZEelJoUDVLQnhseGZIZlBtQUVtRURXNVFwU09QeTBOQ1BtOUhIMHZOM3BPLVRZcVhlVEFCaVN0SUc4TXhncVpzVENpVXIwRjRzWmEySHJ1S090UmNFekhuUG93aGZRd3MtM1FTRC1fWXh3dXN3ZGIzNng3MVFuT1pSLWh1eU1RX2VJT1RiTEVLb3hRaUI3WjFC?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T17:33:00",
+        "pubDate": "2025-08-23T17:33:00Z",
         "source": "news.google.com"
       },
       {
         "title": "A timeline of the Menendez brothers’ double-murder case - AP News",
         "link": "https://news.google.com/rss/articles/CBMivAFBVV95cUxNWVZhWTFIZ0FzRF90cGJMc09nRzNUck9uNXJ4djNfVEhQUnRQV255VW9iUVBSVnFraHJEVTIzdWRaWGU1ekFuckF6RWJiazRPb3ZzNlNtQmhQZktLdFU5c3VkWC1MSlhDY1NpUUNrZkJId1lPNk1sQVdvU0FEOEllei1BWmI4dXN1UVVuWkxISGE4SWF1ZnpYRTlzTVpfQnFaUzllTDJXTldEMEI0bW14T01BOWJjS0FOdVl4Zg?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T03:28:00",
+        "pubDate": "2025-08-23T03:28:00Z",
         "source": "news.google.com"
       },
       {
         "title": "My ex stalked me, so I joined a 'dating safety' app. Then my address was leaked",
         "link": "https://www.bbc.com/news/articles/ce87rer52k3o?at_medium=RSS&at_campaign=rss",
         "description": "Thousands of women who signed up had their data, including images, posts, and comments, leaked.",
-        "pubDate": "2025-08-23T00:34:38",
+        "pubDate": "2025-08-23T00:34:38Z",
         "source": "bbc.com"
       },
       {
         "title": "Small Minnesota county bucking national news desert trend, has 3 family-owned newspapers - AP News",
         "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxPSXBoYm1CS3hEWWx1SnhNMGtmR0o2UldDejRtblA5RnZwYzlTMWdzUzB3YnhJM3VmYkZGMlhwUnRlM3JFMVRHTWtHYU5KOVFSWXBDVy1lcWo4eDlwb1VJbno0clUzci00MXhqSzB1YjY1NTlxdzNPSjV1SDlJYW5VWE5wV1NENnBRQkE?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T20:13:00",
+        "pubDate": "2025-08-22T20:13:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Costa Rican president appears before lawmakers and denies corruption allegations - AP News",
         "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxPbm51VGdjaVh2WGlRa1MxVk1LcGZMeTdUSVdtMDg0d2FCNTdqU2U1S1V0bEVCQUdnb25PSzdUX3ZWbzZWNDIyME1pZV9vNjVVT2JXVDJkMHpJMFI3U0hYYWlpZlN5b203MjJXWU14OFFRSDFTeXlJNkh4Y19ad0FiMC12d0ZFRjMxMTVuTFl2VHRwUQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T19:54:00",
+        "pubDate": "2025-08-22T19:54:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Apple TV+ raises subscription prices worldwide, including in UK",
         "link": "https://www.bbc.com/news/articles/c1le9l6pee5o?at_medium=RSS&at_campaign=rss",
         "description": "The streaming industry has seen a series of price hikes from its major players in the past year.",
-        "pubDate": "2025-08-22T14:22:32",
+        "pubDate": "2025-08-22T14:22:32Z",
         "source": "bbc.com"
       },
       {
         "title": "TikTok puts hundreds of UK content moderator jobs at risk",
         "link": "https://www.bbc.com/news/articles/cgjyp48dp21o?at_medium=RSS&at_campaign=rss",
         "description": "The firm says it's planning to relocate work to its other offices in Europe and invest more in AI.",
-        "pubDate": "2025-08-22T12:32:06",
+        "pubDate": "2025-08-22T12:32:06Z",
         "source": "bbc.com"
       },
       {
         "title": "Olympic champion skier Eileen Gu injured in a training accident in New Zealand - AP News",
         "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxQTjcySjZjWFJWVTF3UWJsTmNBZkJpNWJRU3R0YXkwUXhkN244RmlhMzZrOVV0bUxrN1hZVklUSF9MdzhyOFVHNGROZTF2aFFmQUlCSnN6SWVZLU9iMFBsc25UZ3V3NU1QRTVfVUJJeUhYOWYtaWk1b2hCc2FkT2FWSWhDRFhrLXJXVHdPaVd0UXFCZw?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T07:57:00",
+        "pubDate": "2025-08-22T07:57:00Z",
         "source": "news.google.com"
       },
       {
         "title": "California parole board denies release for Erik Menendez due to misbehavior in prison - AP News",
         "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxNX0tmaEx3ajUySTZHT1Bzc1NNWVp4bjZFc1BqZEdyWlhnclpFNkFIZ21MVVpUSUxtbmNJdjdOYkhXMXZtT0VNQS1TaEdCN0xjWFRWZHNKX255V2ZTTXktay16ZVNxSS1lZ0ZQWktrbGZoMG04RnJmRDlkaldiQjU0eHR0bWRSaU15Tm9aVHJmTEJ2VWQ3NFZSSURnbjVkV0dJRGtwa3FRT3lKYzR2YkE?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T03:06:00",
+        "pubDate": "2025-08-22T03:06:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Elon Musk and X reach settlement with axed Twitter workers",
         "link": "https://www.bbc.com/news/articles/c1ejq154nqzo?at_medium=RSS&at_campaign=rss",
         "description": "Ex-Twitter staff sued the platform after some 6,000 employees were sacked in 2022.",
-        "pubDate": "2025-08-22T02:51:40",
+        "pubDate": "2025-08-22T02:51:40Z",
         "source": "bbc.com"
       },
       {
         "title": "Netanyahu says he will push ahead with Gaza City takeover and renewed ceasefire talks - AP News",
         "link": "https://news.google.com/rss/articles/CBMivwFBVV95cUxOR21UN1RZY0tfTGlnbkJLSUZHUmdPSEFlTEU3YXJvck1wSFVQLWlaUEx0NjBTbFNNSDk1UTBsNDEtTERzTnFSN3U2SlVPMnQtR0ljdzJiay1DTHpxUk1uUnpNdmtnLUtoanJSOVEyTDlja2JwS1NfWlRicXEyS3JVTWxCX1FmQjNqbFc5TWJhYVNVZXVuTmpKZGU4Y04xRThmRVFzMkFzb0R6a3lYWnhUQ3BSNXd4TGtWcC11UDYtZw?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T01:41:00",
+        "pubDate": "2025-08-22T01:41:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Supreme Court lets Trump administration cut $783 million of research funding in anti-DEI push - AP News",
         "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxNOE5kNDcwM1NUejdMMVVCSjZrLTZiYUNSV2xjeGtjQmJMc1liNm1RLUl0VkRpNXdubW54QndMZ3dPci1xSV9xZmFaLU1qMFJvRE4xQllOLXVRYm81aUtYd191YlcwdTNLRmoyRTA4Zko2NVJoZUlxTVgybUJvSmpPdi1GWE80WkZsaHVWTm0wSWE?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T00:06:00",
+        "pubDate": "2025-08-22T00:06:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Computer science graduates struggle to secure their first jobs",
         "link": "https://www.bbc.com/news/articles/cm21dvg8l1go?at_medium=RSS&at_campaign=rss",
         "description": "Companies are using AI to do basic coding tasks instead of hiring junior staff.",
-        "pubDate": "2025-08-21T23:50:34",
+        "pubDate": "2025-08-21T23:50:34Z",
         "source": "bbc.com"
       },
       {
         "title": "4chan will refuse to pay daily online safety fines, lawyer tells BBC",
         "link": "https://www.bbc.com/news/articles/cq68j5g2nr1o?at_medium=RSS&at_campaign=rss",
         "description": "The online message board's lawyers say UK safety laws shouldn't apply to a business based in the US.",
-        "pubDate": "2025-08-21T23:45:55",
+        "pubDate": "2025-08-21T23:45:55Z",
         "source": "bbc.com"
       },
       {
         "title": "Trump blames renewable energy for rising electricity prices. Experts point elsewhere - AP News",
         "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxNUmZPX3BFU2k5d3NDTlNSZUlwTGRGcFo4UTRrdjU2MF9TOVZrWXU2YTk2NEFhY29LbzJCNTJRYjRhY2NrSEdyWVNSQnFaOWk3eG5NNzFBNG9qeFNlQTdkeE13VGtKaElGN1Z2VjJlTGJXS1ZzN2FrdmVqb0YyS3UzM2hmZFFUdS1wYy1kR253SzI0LTB4LXdxSnc5dw?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T21:42:00",
+        "pubDate": "2025-08-21T21:42:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Missing woman's body found in California forest and detectives say her husband has fled to Peru - AP News",
         "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPa3dHTDMtOTVxeU12Z3FuTE1IVjcwY2k2YTBfanVLQWhDT3pWbHJkQVNOVjJMUWJhNlpvWURnd0ZFcE90Y0NtQjBXb2ZDS25qYy1ESGJTWkdCR3NBcUhQM0tGdWR6YlZTZVlmdWwtN1NGenB1c2ZLb3ptamYwNEpqNzZZNHloa2UyUnVhWFJIbzlrY1ZjUUlYOWlPQQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T21:32:00",
+        "pubDate": "2025-08-21T21:32:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Georgia man may have tried to enter CDC campus two days before he attacked agency - AP News",
         "link": "https://news.google.com/rss/articles/CBMifEFVX3lxTE5UNlNZcHNCTWlfZnlqYmk5UmdPang1YWNLN1JIT2RpX3JSdlotS21kVXBkdlpQbXhkNk1nUVgtY21zc245Nm5NVzZuRVNybXJILWFiOXczYWl4ME91dHJXanVpSVFYMUlJNVVpbEU2Y3hVX3IwaWcwdWg2WFU?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T21:00:00",
+        "pubDate": "2025-08-21T21:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Uganda agrees to take deported migrants from US if they don’t have criminal records - AP News",
         "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxNMG5mNjlFbTZpdmFVTjVsd0hEbWRfUHdfN2Njc1BDQl9DVDBPNlBuWDlGbXBOTE1OeFB5YzMteFhxS25ZRzBkVlhYN0lHcXBHaGpzVkQzWnNmaUh0VlFSSWFfS0xocW92c3N2ZmhkWWhlbzZwVHpEWUk2a2pOdnZZNldIOG9YWGFSVUJPbjM3WGhWckhGbml3RTE0NW9CdzJhN3pXWERYR2ZVSUFSNmJyTnZZXzU0cE4zaUE?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T20:23:00",
+        "pubDate": "2025-08-21T20:23:00Z",
         "source": "news.google.com"
       },
       {
         "title": "A newscaster takes us along on her date with an AI companion",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5500249-e1/a-newscaster-takes-us-along-on-her-date-with-an-ai-companion",
         "description": "Despite dating apps and social media advice, romantic connections can be hard to make. Enter artificial intelligence.",
-        "pubDate": "2025-08-21T20:20:25",
+        "pubDate": "2025-08-21T20:20:25Z",
         "source": "npr.org"
       },
       {
         "title": "Wisconsin court commissioner resigns after dispute over immigration warrant - AP News",
         "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxQdHRwcXU4UUM0ajRRTU9qSjl2bWZkYVZZMEZqN1ByZzdpX1JmZ3pqRnJ2Qk02Mm9UWHEyR29iX185QjZwVUlPRFN2Sk1lU0I0bUhva3VidTJ6QWFVOWZCRUpONGZqMGxJcW9iY2pQNkRSVml3b2xvTl9LQzhBTjQ5SE9kQTBRUjQwMFBDUm9BNFI1TURfZnRXc0Y1aW5nN3pnaFNJSGJ4YnZ3djJBWWZrRGp3ZnlibDI1SWc?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T19:06:00",
+        "pubDate": "2025-08-21T19:06:00Z",
         "source": "news.google.com"
       },
       {
         "title": "French streamer's death 'not due to trauma', autopsy finds",
         "link": "https://www.bbc.com/news/articles/cr4e1k6l4lyo?at_medium=RSS&at_campaign=rss",
         "description": "The online personality known as Jean Pormanove was found dead in his home in Nice on Monday.",
-        "pubDate": "2025-08-21T16:47:26",
+        "pubDate": "2025-08-21T16:47:26Z",
         "source": "bbc.com"
       },
       {
         "title": "A Ukrainian startup develops long-range drones and missiles to take the battle to Russia - AP News",
         "link": "https://news.google.com/rss/articles/CBMinwFBVV95cUxOVXhlbVlvODdVbHM0UEJSRUUzUzhVMWc2YVRfcm5IUWYzOEZBX0xZOHhjSjhGaWEyQUVqZ3ZVQy1VMjJKSTVWTkx1XzFTMWZvSENLY2RVSjFoWVkwZzFPRHhBWk5ZdmhMVzAxdEpneklEdGxDWEx2Y2djanBudWg2ak5GUUJRNnBnMUdjcU1Vcmppci1FMnA1cF80aGloMEk?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T13:13:00",
+        "pubDate": "2025-08-21T13:13:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Hundreds of thousands of Grok chats exposed in Google results",
         "link": "https://www.bbc.com/news/articles/cdrkmk00jy0o?at_medium=RSS&at_campaign=rss",
         "description": "Elon Musk's artificial intelligence (AI) chatbot appears to have published messages without users' knowledge.",
-        "pubDate": "2025-08-21T12:55:28",
+        "pubDate": "2025-08-21T12:55:28Z",
         "source": "bbc.com"
       },
       {
         "title": "Netflix signs up another YouTube star with Mark Rober deal",
         "link": "https://www.bbc.com/news/articles/c20939pp04po?at_medium=RSS&at_campaign=rss",
         "description": "The YouTuber and former Nasa engineer is working with Jimmy Kimmel to make a new competition show.",
-        "pubDate": "2025-08-21T11:26:08",
+        "pubDate": "2025-08-21T11:26:08Z",
         "source": "bbc.com"
       },
       {
         "title": "Investigation into 'horrifying' death of French streamer",
         "link": "https://www.bbc.com/news/articles/c1mpjplk4pxo?at_medium=RSS&at_campaign=rss",
         "description": "Raphaël Graven, also known as Jean Pormanove, was found dead at a residence in Contes, a village north of Nice, prosecutors said.",
-        "pubDate": "2025-08-21T07:51:05",
+        "pubDate": "2025-08-21T07:51:05Z",
         "source": "bbc.com"
       },
       {
         "title": "Prosecutors link LA contract to Smartmatic ‘slush fund’ as voting tech firm battles Fox in court - AP News",
         "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxNY19JbjdZT3hoalpfZWJlVFk2b01GWkg4X1hNOXN2NlBWTTlUYnhfc2VodHAxV2lVMWphSE1jbnc1TnBrckJZemNzczVqdVBzeGpMUkJfTzFtZGE1SlRnWkRwTWFXVGJxajRtY3QxRDFKVnB6eFk1X200aUd5cUU5T1h2M3FSaGZWVGdGbjd0NEctS3ZPSGdjSDFGWVd6dXJLM3FPLXNzN0trUnF5R3RJ?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T04:03:00",
+        "pubDate": "2025-08-21T04:03:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Sony raises PlayStation 5 prices in US as tariff fears persist",
         "link": "https://www.bbc.com/news/articles/cy081prg9jjo?at_medium=RSS&at_campaign=rss",
         "description": "The Japanese technology giant cited economic challenges as it raised prices for the consoles by around $50.",
-        "pubDate": "2025-08-21T01:45:10",
+        "pubDate": "2025-08-21T01:45:10Z",
         "source": "bbc.com"
       },
       {
         "title": "Microsoft employee protests lead to 18 arrests as company reviews its work with Israel's military - AP News",
         "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxOQlpveGJxOGlNXzFtQlJQT0NfQlBBMWpvMllwY2NHVTFOdnZoWnNKWmNrUXBsT3BaMkNHVXVfZndaZGZSZGtDX3ZtaFZOeWY2bkdIQlMtZTlUX3BzNTZsQ3kya2Fwa0RRa09BU2VXbTFoWGhtQmlyTlpDN0dMb3J6cDZaYW5HaUVOV3pYZDRPU0pJZlBtY3M1eUMzNmE?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T23:04:00",
+        "pubDate": "2025-08-20T23:04:00Z",
         "source": "news.google.com"
       },
       {
         "title": "At least 600 CDC employees are getting final termination notices, union says - AP News",
         "link": "https://news.google.com/rss/articles/CBMie0FVX3lxTFAwcldOS3A1TW5yTjRMSV9STXZSM3p3MjBqaEJkbWRGanRUb3FlUGIteFkyWlRnX0pyVGVsYmVNT1htTkFxdGZVWFVNd2hIdkR1NG5VWjY5Y1loQVc1ZUZON3hHa2pfRFVjMlVDYWg5M1dZU1FSMDVUeVZoNA?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T22:49:00",
+        "pubDate": "2025-08-20T22:49:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Judge denies Justice Department request to unseal Epstein grand jury transcripts - AP News",
         "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxNS0VjSWQtVkNSUjFWblRYa3MzVU5yR1J1NjlRbzYwdmNHUmRCYlRIcnFCR2dZdmV1M0hHOXJsZGlrUW1jYnFRTktfWmNsdzRXRmdpbFNWbzQyRzUwQ2c2RlVJVE5FSFk5Rkt2NzJRZHpFU1NsUnljSWlCNHEtWkMwX0V1UVl0US1IMDhRVU1DRQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T22:35:00",
+        "pubDate": "2025-08-20T22:35:00Z",
+        "source": "news.google.com"
+      },
+      {
+        "title": "Target CEO to step down amid company struggles - AP News",
+        "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxNMnNiX0ZidmN5MDNNbTE3Q05XclpaSlAySFJyUkJ0YlBsUXhjY051WTYzV0dQQTdGOTlNb0V3UFlhdGI0QzVqUS1CTVFvTWxtY25tT3JYcFdFdDFkS3lEUmpkOGQ3WmZNWGRSQVhaUm5ILUZoOUN1anlfX0dUR0FLamtUMllnYmNaZFJQbDh1bHdibm95VnVOSHJrSE9nSnpi?oc=5",
+        "description": "",
+        "pubDate": "2025-08-20T18:39:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Microsoft boss troubled by rise in reports of 'AI psychosis'",
         "link": "https://www.bbc.com/news/articles/c24zdel5j18o?at_medium=RSS&at_campaign=rss",
         "description": "Mustafa Suleyman said there was still \"zero evidence of AI consciousness today\".",
-        "pubDate": "2025-08-20T16:36:03",
+        "pubDate": "2025-08-20T16:36:03Z",
         "source": "bbc.com"
       },
       {
         "title": "Human rights regulator criticises Met's use of facial recognition cameras",
         "link": "https://www.bbc.com/news/articles/c1kzgx4v2pko?at_medium=RSS&at_campaign=rss",
         "description": "The Equality and Human Rights Commission says it believes the Met's use of the tech is unlawful.",
-        "pubDate": "2025-08-20T16:18:42",
+        "pubDate": "2025-08-20T16:18:42Z",
         "source": "bbc.com"
       },
       {
         "title": "Trump thinks owning a piece of Intel would be a good deal for the US. Here’s what to know - AP News",
         "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxNU0FzSU8xeEtYaGZPcU1ZUVY3TkNzdTZXQ0dNbUFrc29jVzZJMnpNMXp4RUFxamVQTXVhUVlLTVdSNmxwODNKLXJhSUVoUlRXVndUVXVydTRpVXpXYXJHaEVROXp6Qm9DOFdYcGZTM3kxZWlCd2s4WjFQZk44eEU0QWlJbUFxcjlaNVhXMkVyLTBpbzdUcVZSVkJWMzdNQmRxTk1FTg?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T12:03:00",
+        "pubDate": "2025-08-20T12:03:00Z",
         "source": "news.google.com"
       },
       {
         "title": "German foreign minister backs Israel and Palestine two-state solution during Indonesia visit - AP News",
         "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxQTUEwVFUyN2NUSHRjVDdzdTcyT3haMzBSMWtxaGIxTjBLcmFQQUVDRnJXSXFySGhHczFOYjV0YkVZMEtLUE9xNEhldG05TGo4cWpjSnFZTFBHcVBpX3NqMEpsdUpDOFNJMjQ3bGpnTFZ3S0IxdHVmX3NuaV9qTG1JOHZrbE9PbGZSY2ltUmpkdi1PYkgwMXBzdkstUVRoRWNFS0p4TUpZY2RwSXozYTFuanN3?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T10:46:00",
+        "pubDate": "2025-08-20T10:46:00Z",
         "source": "news.google.com"
       },
       {
         "title": "These brain implants speak your mind — even when you don't want to",
         "link": "https://www.npr.org/sections/shots-health-news/2025/08/20/nx-s1-5506334/brain-computer-implant-speak-inner-speech-mind",
         "description": "Brain-implanted devices that allow paralyzed people to speak can also decode words they imagine, but don't intend to share.",
-        "pubDate": "2025-08-20T10:00:00",
+        "pubDate": "2025-08-20T10:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "US in talks over 10% Intel stake, White House confirms",
         "link": "https://www.bbc.com/news/articles/c620gg77epxo?at_medium=RSS&at_campaign=rss",
         "description": "The potential deal could involve swapping government grants for shares in the chip making giant.",
-        "pubDate": "2025-08-20T06:37:52",
+        "pubDate": "2025-08-20T06:37:52Z",
         "source": "bbc.com"
       },
       {
         "title": "A Gaza-bound ship that left Cyprus with 1,200 tons of food aid nears Israeli port - AP News",
         "link": "https://news.google.com/rss/articles/CBMinwFBVV95cUxON2lITDRVOWd6QUJFT0xMbi1YaFN1ZWoyWTA1OERJcWxjS3VuanhxZ3czYjloUnFoNUhqaVBhdDJLaFVpazJxLTFjZjBFb0NoNENfT3NSSDJPRkZESk1WbFdBcXozTjBLcWpNblF6ZXExRTA1TGoyMlM2THZERENGa2pxUlVQYmd0YUQyYWI0UkVkRTJlWFVwWHBVVWJEZHM?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T03:57:00",
+        "pubDate": "2025-08-20T03:57:00Z",
         "source": "news.google.com"
       },
       {
         "title": "UK backs down in Apple privacy row, US says",
         "link": "https://www.bbc.com/news/articles/cdj2m3rrk74o?at_medium=RSS&at_campaign=rss",
         "description": "UK authorities have demanded access to Apple users' protected files when required for investigations.",
-        "pubDate": "2025-08-19T21:45:56",
+        "pubDate": "2025-08-19T21:45:56Z",
         "source": "bbc.com"
       },
       {
         "title": "Tech Life",
         "link": "https://www.bbc.co.uk/sounds/play/w3ct6zp4?at_medium=RSS&at_campaign=rss",
         "description": "A special from Edinburgh, where art and performance meet tech with spectacular results.",
-        "pubDate": "2025-08-19T19:30:00",
+        "pubDate": "2025-08-19T19:30:00Z",
         "source": "bbc.co.uk"
       },
       {
         "title": "Research suggests doctors might quickly become dependent on AI",
         "link": "https://www.npr.org/sections/shots-health-news/2025/08/19/nx-s1-5506292/doctors-ai-artificial-intelligence-dependent-colonoscopy",
         "description": "A study in Poland found that doctors appeared less likely to detect abnormalities during colonoscopies on their own after they'd grown used to help from an AI tool.",
-        "pubDate": "2025-08-19T10:57:42",
+        "pubDate": "2025-08-19T10:57:42Z",
         "source": "npr.org"
       },
       {
         "title": "An AI divide is growing in schools. This camp wants to level the playing field",
         "link": "https://www.npr.org/2025/08/19/nx-s1-5503984/ai-summer-camp-schools-education",
         "description": "For years, research has shown a digital divide when it comes to schools teaching about new technologies. Educators worry that this could leave some students behind in an AI-powered economy.",
-        "pubDate": "2025-08-19T09:25:07",
+        "pubDate": "2025-08-19T09:25:07Z",
         "source": "npr.org"
       },
       {
         "title": "Stop children using VPNs to watch porn, ministers told",
         "link": "https://www.bbc.com/news/articles/cn438z3ejxyo?at_medium=RSS&at_campaign=rss",
         "description": "The children's commissioner for England tells the BBC virtual private networks are a \"loophole that needs closing.",
-        "pubDate": "2025-08-19T05:39:49",
+        "pubDate": "2025-08-19T05:39:49Z",
         "source": "bbc.com"
       },
       {
         "title": "Intel shares jump as Softbank to buy $2bn stake in chip giant",
         "link": "https://www.bbc.com/news/articles/cly4vn1nxg7o?at_medium=RSS&at_campaign=rss",
         "description": "The announcement comes hours after reports that the White House is in talks over taking a 10% stake in Intel.",
-        "pubDate": "2025-08-19T02:06:02",
+        "pubDate": "2025-08-19T02:06:02Z",
         "source": "bbc.com"
       },
       {
         "title": "How to destroy harmful 'forever chemicals'",
         "link": "https://www.bbc.com/news/articles/clydd630pxzo?at_medium=RSS&at_campaign=rss",
         "description": "PFAS were once prized for their durability, but now firms are developing ways to destroy them.",
-        "pubDate": "2025-08-18T23:22:14",
+        "pubDate": "2025-08-18T23:22:14Z",
         "source": "bbc.com"
       },
       {
         "title": "Meta investigated over AI having 'sensual' chats with children",
         "link": "https://www.bbc.com/news/articles/c3dpmlvx1k2o?at_medium=RSS&at_campaign=rss",
         "description": "The leak has led to backlash amid reports the tech giant's legal staff approved the conversations.",
-        "pubDate": "2025-08-18T12:04:06",
+        "pubDate": "2025-08-18T12:04:06Z",
         "source": "bbc.com"
       },
       {
         "title": "What's behind the Trump administration's immigration memes?",
         "link": "https://www.npr.org/2025/08/18/nx-s1-5482921/memes-white-house-dhs-social-media-trump",
         "description": "White supremacist tropes and ironic viral jokes illustrate the administration's project of redefining who belongs in the United States.",
-        "pubDate": "2025-08-18T09:48:28",
+        "pubDate": "2025-08-18T09:48:28Z",
         "source": "npr.org"
       },
       {
         "title": "Should Europe wean itself off US tech?",
         "link": "https://www.bbc.com/news/articles/c3dpr2zkny0o?at_medium=RSS&at_campaign=rss",
         "description": "Just three US firms provide 70% of Europe's cloud-computing, leading to fears of overreliance.",
-        "pubDate": "2025-08-17T23:03:19",
+        "pubDate": "2025-08-17T23:03:19Z",
         "source": "bbc.com"
-      },
-      {
-        "title": "AI is driving a data center boom in rural America. Locals are divided on the benefits",
-        "link": "https://www.npr.org/2025/08/17/nx-s1-5461467/ai-is-driving-a-data-center-boom-in-rural-america-locals-are-divided-on-the-benefits",
-        "description": "Artificial intelligence is driving a data center building boom across rural America, including in central Washington. But critics say the centers do not produce enough jobs — and drain resources.",
-        "pubDate": "2025-08-17T13:02:15",
-        "source": "npr.org"
       }
     ],
     "Science": [
@@ -1062,350 +1062,350 @@
         "title": "The U.S. wants to mine the deep sea for rare minerals. Science shows what's at stake",
         "link": "https://www.npr.org/2025/08/24/nx-s1-5455940/the-u-s-wants-to-mine-the-deep-sea-for-rare-minerals-science-shows-whats-at-stake",
         "description": "Some countries, including the U.S., want to mine the seafloor for rare earth elements used in smartphones and electric cars. But other nations are concerned about the environmental impact.",
-        "pubDate": "2025-08-24T12:51:58",
+        "pubDate": "2025-08-24T12:51:58Z",
         "source": "npr.org"
       },
       {
         "title": "Key things to know about how Trump's war on higher education has ensnared an unexpected campus - AP News",
         "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxPWjdTUF8tSkNlVXBGN2VVQkdhaVVDT3pmNllsMnhYSHN3OG5tcG5iZnpmN09jS050dEgtVjdvSEo5YmdKMVNuUHBJcWtrRDdyRzZNdmtOalFXV1lYa1A1Y2lGVXVVai0wdm5aNGE1My0yYUo4WWxfeGlMeW5iaF9TMWVpM002S1J5YXBRd29KZjZhYTdna2pqVDFxVmhLU1J6QXJLUFZWQjRDY3ZSVXVSVWxFMA?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T15:29:00",
+        "pubDate": "2025-08-23T15:29:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Hawaii's Kilauea volcano erupts again and shoots lava for 31st time since December",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5513910/hawaii-kilauea-volcano-erupts-again-shoots-lava",
         "description": "Hawaii's Kilauea volcano resumed erupting Friday by shooting an arc of lava 100 feet into the air and across a section of its summit crater floor.",
-        "pubDate": "2025-08-23T13:36:49",
+        "pubDate": "2025-08-23T13:36:49Z",
         "source": "npr.org"
       },
       {
         "title": "The EV tax credit ends soon — but there's a little bit of wiggle room for car buyers",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5511244/ev-tax-credit-deadline-irs",
         "description": "A federal EV tax credit worth up to $7,500 ends Sept. 30. But the IRS has just clarified that shoppers don't need to actually have the keys in hand by the deadline to get the credit.",
-        "pubDate": "2025-08-22T19:12:24",
+        "pubDate": "2025-08-22T19:12:24Z",
         "source": "npr.org"
       },
       {
         "title": "New dinosaur named after record-breaking sailor",
         "link": "https://www.bbc.com/news/articles/c87ew7qq4wwo?at_medium=RSS&at_campaign=rss",
         "description": "The medium-sized herbivore once roamed the floodplains of what is now the Island's south-west coast.",
-        "pubDate": "2025-08-22T10:45:09",
+        "pubDate": "2025-08-22T10:45:09Z",
         "source": "bbc.com"
       },
       {
         "title": "Supreme Court allows NIH to stop making nearly $800M in research grants for now",
         "link": "https://www.npr.org/2025/08/21/g-s1-84441/supreme-court-nih-grants",
         "description": "But the court, in its emergency-docket order, left in place by a 5-4 order a lower court ruling that threw out National Institutes of Health memos that enforced the administration's policies.",
-        "pubDate": "2025-08-21T21:41:09",
+        "pubDate": "2025-08-21T21:41:09Z",
         "source": "npr.org"
       },
       {
         "title": "A new study challenges what we know about how amputation alters the human brain",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5506040/a-new-study-challenges-what-we-know-about-how-amputation-alters-the-human-brain",
         "description": "Even years after a person has lost an arm, the brain faithfully maintains the circuits that once controlled the missing limb.",
-        "pubDate": "2025-08-21T20:20:19",
+        "pubDate": "2025-08-21T20:20:19Z",
         "source": "npr.org"
       },
       {
         "title": "This week in science: chocolate, daytime drowsiness and seabirds' bathroom habits",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5502833/this-week-in-science-chocolate-daytime-drowsiness-and-seabirds-bathroom-habits",
         "description": "NPR's Hannah Chinn and Emily Kwong talk about the microbes behind great-tasting chocolate, possible reasons for daytime drowsiness, and a curious observation about the poop of seabirds.",
-        "pubDate": "2025-08-21T20:20:13",
+        "pubDate": "2025-08-21T20:20:13Z",
         "source": "npr.org"
       },
       {
         "title": "Artificial light has essentially lengthened birds' day",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5507165/light-pollution-bird-day-hour-longer",
         "description": "Millions of audio recordings of hundreds of bird species have revealed that artificial light is making the birds wake up earlier and go to bed later.",
-        "pubDate": "2025-08-21T18:00:00",
+        "pubDate": "2025-08-21T18:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "Filipino forces on alert after China deploys coast guard ships closer to disputed shoal - AP News",
         "link": "https://news.google.com/rss/articles/CBMitwFBVV95cUxOOG1xOXdSQkFBRVdIaHJZa3hFNDVvVFlDMUhDOGhpY0s4UHZlUG5MamR6Mm5EZU9SblJxbFF1Tm8xUk55TDdDSXliNU5IUGRQaHFtZkVGd20yZkgzWWFyZUFzZUs5T0hTNEF2MVh6cV9hTUxmSDhzUzYxOU5Pc2pCdk1yZE4yWUg4SV9uQWZXeFp4WE9acEhUYjE1QUpIZW50Y2gwTlpvNk9DTHlDRktiQThnVlhYRTQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T17:12:00",
+        "pubDate": "2025-08-21T17:12:00Z",
         "source": "news.google.com"
       },
       {
         "title": "BBC Inside Science",
         "link": "https://www.bbc.co.uk/sounds/play/m002hb9f?at_medium=RSS&at_campaign=rss",
         "description": "The science of extraterrestrial solar panels and whether they can power our energy needs.",
-        "pubDate": "2025-08-21T16:00:00",
+        "pubDate": "2025-08-21T16:00:00Z",
         "source": "bbc.co.uk"
       },
       {
         "title": "Bones of ancient child suggest humans could have interbred with Neanderthals earlier than thought - AP News",
         "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxOaE1HYWZWU3IwWHJVZ0NoQjNfYl9HMzE5dE8yQ0l2b2xhNHFZLUh0RmFsZWNGc0JXUXYyR2x1V0k1OTE4a3dSQmtNak9FRXRtU1VQSmRqTld5RnVTMWVQRUgxbmdFS1hEZUpUeDRfb3ZIT3VLMUdYTnBPM1dha1hfVkVDWUc1N0t5Z3VpRWwwUkhWNUNnekl2QmZIYVhpSFB0VGVEc2NvUDhmNktJQ3c?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T15:45:00",
+        "pubDate": "2025-08-21T15:45:00Z",
         "source": "news.google.com"
       },
       {
         "title": "New study raises questions about effectiveness of wolf hunting as a tool to help ranchers",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5507219/wolf-hunting-livestock-research-human-wildlife-conflict",
         "description": "One of the goals of controversial wolf hunts in the Western U.S. is to help reduce the burden on ranchers, who lose livestock to wolves every year. A new study finds that those hunts have had a measurable, but small effect on livestock depredations.",
-        "pubDate": "2025-08-21T15:07:51",
+        "pubDate": "2025-08-21T15:07:51Z",
         "source": "npr.org"
       },
       {
         "title": "The transitions of aging: How parents and adult children can adjust",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5506233/transitions-aging-how-parents-adult-children-can-adjust",
         "description": "As people age, they may be surprised to find that younger folks don't understand what they're going through, but adult children or caretakers can do a lot to help older people adjust to a new reality.",
-        "pubDate": "2025-08-21T10:00:00",
+        "pubDate": "2025-08-21T10:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "A 'black moon' will appear in the sky this weekend, but you won't see it. Here's why",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5505395/black-new-moon-explainer",
         "description": "A black moon is a type of new moon, when the moon is nearly between Earth and the sun.",
-        "pubDate": "2025-08-21T09:00:00",
+        "pubDate": "2025-08-21T09:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "How many giraffe species are in Africa? New scientific analysis quadruples the count - AP News",
         "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxOS1QxWDN3UWN5S2ttRjdpRjlJWGptUTZWR1BGUm1ZZl9Ca2hXbWJZRFFYVURDaDZPd2wtb0tFUVBmbkYzVVlmclY5X181RDBlblNQaG5FTEVucUtkTGdzNEhzUl94M0xVRkk4X0J0YzI0X0ZEdU42Qk9pekladFczQkhUREt1SHBrMlE?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T08:00:00",
+        "pubDate": "2025-08-21T08:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Will there be a drought where I live?",
         "link": "https://www.bbc.com/news/articles/crk661074ejo?at_medium=RSS&at_campaign=rss",
         "description": "We take a look at river, reservoir and groundwater levels after a particularly dry few months.",
-        "pubDate": "2025-08-20T19:10:59",
+        "pubDate": "2025-08-20T19:10:59Z",
         "source": "bbc.com"
       },
       {
         "title": "Scientists get a rare peek inside of an exploding star - AP News",
         "link": "https://news.google.com/rss/articles/CBMilAFBVV95cUxQblhRdUxiRlZvZGduMkhyTlNVcThrc1Z6S3pJQ3ktTUpmY001WEIzWmV4Qkx5RkFBd1lQbndaOU0xVkdxcmVfXzBONk9USEhFQ2gzWkFfV1dGOHI2OFhWV29XNnYtbnY5UlRUNTFoWFlWVS1ORUttTE5zekJKMGx5bHlySG9xRU5CMjZ0MTA0Z0IwZzZi?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T17:36:00",
+        "pubDate": "2025-08-20T17:36:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Scientists make 'superfood' that could save honeybees",
         "link": "https://www.bbc.com/news/articles/c776kynn771o?at_medium=RSS&at_campaign=rss",
         "description": "We rely on honeybees to pollinate our crops and a new food could protect them from growing threats.",
-        "pubDate": "2025-08-20T15:03:02",
+        "pubDate": "2025-08-20T15:03:02Z",
         "source": "bbc.com"
       },
       {
         "title": "UK independent space agency scrapped to cut costs",
         "link": "https://www.bbc.com/news/articles/c4gmjm8z47jo?at_medium=RSS&at_campaign=rss",
         "description": "Britain's space agency is set to be scrapped - a scientist fears the UK space sector could fall behind as a result",
-        "pubDate": "2025-08-20T00:35:23",
+        "pubDate": "2025-08-20T00:35:23Z",
         "source": "bbc.com"
       },
       {
         "title": "Why scientists hope seabed mud could reveal Antarctic Ocean secrets",
         "link": "https://www.bbc.com/news/articles/cm2vz9jg8jzo?at_medium=RSS&at_campaign=rss",
         "description": "How long tubes of mud - drilled out of the Antarctic seafloor - could reveal how the frozen continent is changing.",
-        "pubDate": "2025-08-18T23:21:37",
+        "pubDate": "2025-08-18T23:21:37Z",
         "source": "bbc.com"
       },
       {
         "title": "Leaves falling, berries ripe, but it's hot. Is autumn coming early?",
         "link": "https://www.bbc.com/news/articles/c2enmn7j3zjo?at_medium=RSS&at_campaign=rss",
         "description": "Has autumn come sooner than expected to the UK - and does it even matter if it has?",
-        "pubDate": "2025-08-16T23:12:36",
+        "pubDate": "2025-08-16T23:12:36Z",
         "source": "bbc.com"
       },
       {
         "title": "Global plastic talks collapse as countries remain deeply divided",
         "link": "https://www.bbc.com/news/articles/cvgpddpldleo?at_medium=RSS&at_campaign=rss",
         "description": "The latest round of UN-led talks have ended in deadlock, with disputes over plastic production and recycling.",
-        "pubDate": "2025-08-15T11:57:06",
+        "pubDate": "2025-08-15T11:57:06Z",
         "source": "bbc.com"
       },
       {
         "title": "Rabbits with ‘horns’ in Colorado are being called ‘Frankenstein bunnies.’ Here’s why - AP News",
         "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxPZzRWcjctUkJSMnFzalZUOGN2ZHI3LTVjYmtyVWg3WDZCd1ZlcDEzOXZjRkROdWMtcktaSl9NN21OYjhOeDNneEN4UlU2UmROaG9lWVYwZnZjWG4zLWJzTlloSnI4Q0VERXFaYy0tQVZVSGxNUlNCUUZtTF9IYXVUeUxod3pPOHg4TG9FblVfczljM3J1MHFLQmVwaGNDSmlZUS1KWlpZcmRzdGJMU2lBbkpFazN3Snhid3c?oc=5",
         "description": "",
-        "pubDate": "2025-08-15T07:00:00",
+        "pubDate": "2025-08-15T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Hot, dry summers bring new 'firewave' risk to UK cities, scientists warn",
         "link": "https://www.bbc.com/news/articles/c9vd79x97zlo?at_medium=RSS&at_campaign=rss",
         "description": "Rising temperatures are increasing the chances of multiple wildfires at the same time, researchers say.",
-        "pubDate": "2025-08-14T00:04:14",
+        "pubDate": "2025-08-14T00:04:14Z",
         "source": "bbc.com"
       },
       {
         "title": "Evacuations in Alaska after glacial melt raises fears of record flooding",
         "link": "https://www.bbc.com/news/articles/c4gejyg8l7vo?at_medium=RSS&at_campaign=rss",
         "description": "Meltwater is escaping from a basin that is dammed by a glacier - prompting fears of a deluge in state capital Juneau.",
-        "pubDate": "2025-08-13T12:32:13",
+        "pubDate": "2025-08-13T12:32:13Z",
         "source": "bbc.com"
       },
       {
         "title": "Record warm seas help to bring extraordinary new species to UK waters",
         "link": "https://www.bbc.com/news/articles/c05enyryqvmo?at_medium=RSS&at_campaign=rss",
         "description": "The UK's seas have had their warmest first seven months of the year on average since records began.",
-        "pubDate": "2025-08-11T00:36:06",
+        "pubDate": "2025-08-11T00:36:06Z",
         "source": "bbc.com"
       },
       {
         "title": "Jim Lovell, Apollo 13 astronaut, dies aged 97",
         "link": "https://www.bbc.com/news/articles/cl7y8zq5xpno?at_medium=RSS&at_campaign=rss",
         "description": "The commander of Apollo 13 famously rescued his men from near certain death in space.",
-        "pubDate": "2025-08-09T07:01:11",
+        "pubDate": "2025-08-09T07:01:11Z",
         "source": "bbc.com"
       },
       {
         "title": "Nasa Apollo missions: Stories of the last Moon men",
         "link": "https://www.bbc.com/news/articles/c4g9yde95yyo?at_medium=RSS&at_campaign=rss",
         "description": "Of the 24 Nasa astronauts who travelled to the Moon in the Apollo missions of the 1960s and 1970s, just five remain.",
-        "pubDate": "2025-08-08T21:31:57",
+        "pubDate": "2025-08-08T21:31:57Z",
         "source": "bbc.com"
       },
       {
         "title": "Southern European butterfly spotted in UK for first time",
         "link": "https://www.bbc.com/news/articles/cwy1wgly21zo?at_medium=RSS&at_campaign=rss",
         "description": "Experts have tracked the Southern Small White's expansion northwards through Europe over decades.",
-        "pubDate": "2025-08-08T01:06:28",
+        "pubDate": "2025-08-08T01:06:28Z",
         "source": "bbc.com"
       },
       {
         "title": "New checks to stop waste tyres being sent to furnaces",
         "link": "https://www.bbc.com/news/articles/cj9wepemrj8o?at_medium=RSS&at_campaign=rss",
         "description": "Campaigners warn the move will not close all the recycling loopholes being exploited by criminals.",
-        "pubDate": "2025-08-07T05:04:49",
+        "pubDate": "2025-08-07T05:04:49Z",
         "source": "bbc.com"
       },
       {
         "title": "Oceangate's Titan whistleblower: 'People were sold a lie'",
         "link": "https://www.bbc.com/news/articles/cy0wpe9479wo?at_medium=RSS&at_campaign=rss",
         "description": "A former Oceangate employee says he told US authorities about safety concerns with the sub before it imploded.",
-        "pubDate": "2025-08-06T05:35:42",
+        "pubDate": "2025-08-06T05:35:42Z",
         "source": "bbc.com"
       },
       {
         "title": "Nasa to put nuclear reactor on the Moon by 2030 - US media",
         "link": "https://www.bbc.com/news/articles/cev2dylxv74o?at_medium=RSS&at_campaign=rss",
         "description": "The reactor would provide power for humans on the Moon but there are questions about feasibility.",
-        "pubDate": "2025-08-05T11:36:24",
+        "pubDate": "2025-08-05T11:36:24Z",
         "source": "bbc.com"
       },
       {
         "title": "Mission begins to save snails threatened by own beauty",
         "link": "https://www.bbc.com/news/articles/clyrv8ndzzjo?at_medium=RSS&at_campaign=rss",
         "description": "Researchers in Cuba and the UK are working together to reveal the biological secrets of the beautiful but endangered Polymita snail.",
-        "pubDate": "2025-08-04T00:46:34",
+        "pubDate": "2025-08-04T00:46:34Z",
         "source": "bbc.com"
       },
       {
         "title": "Russian volcano erupts for first time in more than 500 years",
         "link": "https://www.bbc.com/news/articles/c0r7qlwg4zro?at_medium=RSS&at_campaign=rss",
         "description": "The eruption of a volcano in Russia's Kamchatka peninsula may be linked to a massive earthquake last week, experts say.",
-        "pubDate": "2025-08-03T09:05:37",
+        "pubDate": "2025-08-03T09:05:37Z",
         "source": "bbc.com"
       },
       {
         "title": "Melting glaciers threaten to wipe out European villages - is the steep cost to protect them worth it?",
         "link": "https://www.bbc.com/news/articles/cj4w9ggzxv4o?at_medium=RSS&at_campaign=rss",
         "description": "Switzerland spends almost $500m a year on protective structures. Is it worth it - or, as some suggest, should people move away from the mountain villages at risk?",
-        "pubDate": "2025-08-02T23:06:56",
+        "pubDate": "2025-08-02T23:06:56Z",
         "source": "bbc.com"
       },
       {
         "title": "'Communities' of strange, extreme life seen for first time in deep ocean",
         "link": "https://www.bbc.com/news/articles/c3wnqe5j99do?at_medium=RSS&at_campaign=rss",
         "description": "A Chinese-led research team captures pictures of life at depths of more than 9km in the northwest Pacific Ocean.",
-        "pubDate": "2025-07-31T00:02:31",
+        "pubDate": "2025-07-31T00:02:31Z",
         "source": "bbc.com"
       },
       {
         "title": "Why did Russian mega earthquake not cause more tsunami damage?",
         "link": "https://www.bbc.com/news/articles/c0l6pj7kjg7o?at_medium=RSS&at_campaign=rss",
         "description": "The earthquake was one of the strongest ever recorded, but its tsunami was not as bad as feared.",
-        "pubDate": "2025-07-30T16:09:03",
+        "pubDate": "2025-07-30T16:09:03Z",
         "source": "bbc.com"
       },
       {
         "title": "Why plane turbulence is becoming more frequent - and more severe",
         "link": "https://www.bbc.com/news/articles/ckgy7jx082ro?at_medium=RSS&at_campaign=rss",
         "description": "Flights are getting bumpier, thanks in part to climate change. But new studies are looking into innovative potential ways to turbulence-proof wings - using AI and owls",
-        "pubDate": "2025-07-29T23:00:12",
+        "pubDate": "2025-07-29T23:00:12Z",
         "source": "bbc.com"
       },
       {
         "title": "New Brazil development law risks Amazon deforestation, UN expert warns",
         "link": "https://www.bbc.com/news/articles/cy98jqr4p0xo?at_medium=RSS&at_campaign=rss",
         "description": "A new environmental licensing law has been criticised by environmentalists as Brazil prepares for COP30.",
-        "pubDate": "2025-07-29T21:36:53",
+        "pubDate": "2025-07-29T21:36:53Z",
         "source": "bbc.com"
       },
       {
         "title": "US to scrap landmark finding that sets limit on carbon emissions",
         "link": "https://www.bbc.com/news/articles/c0mlzz1gy39o?at_medium=RSS&at_campaign=rss",
         "description": "Experts warn the move will severely curb the federal government's ability to combat climate change.",
-        "pubDate": "2025-07-29T18:42:33",
+        "pubDate": "2025-07-29T18:42:33Z",
         "source": "bbc.com"
       },
       {
         "title": "Thousands of river pollution tests cancelled because of staff shortages",
         "link": "https://www.bbc.com/news/articles/cx24xy8zgp4o?at_medium=RSS&at_campaign=rss",
         "description": "Testing programmes affected include those monitoring the impact of drought.",
-        "pubDate": "2025-07-24T03:12:14",
+        "pubDate": "2025-07-24T03:12:14Z",
         "source": "bbc.com"
       },
       {
         "title": "Unique 1.5m year-old ice to be melted to unlock mystery",
         "link": "https://www.bbc.com/news/articles/c5ygwd6yj28o?at_medium=RSS&at_campaign=rss",
         "description": "BBC News went inside -23C freezers to see the ice that could \"revolutionise\" our knowledge of climate change.",
-        "pubDate": "2025-07-18T00:18:22",
+        "pubDate": "2025-07-18T00:18:22Z",
         "source": "bbc.com"
       },
       {
         "title": "Kew Gardens' Palm House will close for five years for major makeover",
         "link": "https://www.bbc.com/news/articles/cpwq08rxxklo?at_medium=RSS&at_campaign=rss",
         "description": "The 175-year-old glass house will begin a £50m renovation in 2027.",
-        "pubDate": "2025-07-15T23:01:44",
+        "pubDate": "2025-07-15T23:01:44Z",
         "source": "bbc.com"
       },
       {
         "title": "The fate of the Sycamore Gap tree has shed light on a deeper concern",
         "link": "https://www.bbc.com/news/articles/cnvmpz5qqe5o?at_medium=RSS&at_campaign=rss",
         "description": "The felling has prompted calls for stricter legal protections for other trees and drawn attention to wider issues",
-        "pubDate": "2025-07-15T00:04:28",
+        "pubDate": "2025-07-15T00:04:28Z",
         "source": "bbc.com"
       },
       {
         "title": "Tiny creatures gorge, get fat, and help fight global warming",
         "link": "https://www.bbc.com/news/articles/c628nnz3rp9o?at_medium=RSS&at_campaign=rss",
         "description": "Scientists find out how the epic deep sea migration of a tiny animal is storing planet-warming carbon.",
-        "pubDate": "2025-07-04T23:10:52",
+        "pubDate": "2025-07-04T23:10:52Z",
         "source": "bbc.com"
       },
       {
         "title": "Ancient Egyptian history may be rewritten by DNA bone test",
         "link": "https://www.bbc.com/news/articles/c1dnnyz0z6do?at_medium=RSS&at_campaign=rss",
         "description": "A DNA bone test on a man who lived 4,500 years ago sheds new light on the rise of Ancient Egypt.",
-        "pubDate": "2025-07-02T15:01:49",
+        "pubDate": "2025-07-02T15:01:49Z",
         "source": "bbc.com"
       },
       {
         "title": "Recent droughts are 'slow-moving global catastrophe' - UN report",
         "link": "https://www.bbc.com/news/articles/ckg33r1xgymo?at_medium=RSS&at_campaign=rss",
         "description": "It says drought has compounded poverty, hunger, and energy insecurity worldwide.",
-        "pubDate": "2025-07-02T12:31:51",
+        "pubDate": "2025-07-02T12:31:51Z",
         "source": "bbc.com"
       },
       {
         "title": "Work begins to create artificial human DNA from scratch",
         "link": "https://www.bbc.com/news/articles/c6256wpn97ro?at_medium=RSS&at_campaign=rss",
         "description": "Scientists start a controversial project to create the building blocks of human life, in what is thought to be a world first.",
-        "pubDate": "2025-06-26T00:09:45",
+        "pubDate": "2025-06-26T00:09:45Z",
         "source": "bbc.com"
       },
       {
         "title": "India sends its first astronaut into space in 41 years",
         "link": "https://www.bbc.com/news/articles/cz09lx2gjm4o?at_medium=RSS&at_campaign=rss",
         "description": "Group Captain Shubhanshu Shukla has become only the second Indian to travel to space.",
-        "pubDate": "2025-06-25T06:38:38",
+        "pubDate": "2025-06-25T06:38:38Z",
         "source": "bbc.com"
       }
     ],
@@ -1414,351 +1414,351 @@
         "title": "Canada's retaliatory tariffs have left the U.S. wine industry reeling",
         "link": "https://www.npr.org/2025/08/24/nx-s1-5502688/canadas-retaliatory-tariffs-have-left-the-u-s-wine-industry-reeling",
         "description": "NPR's Ayesha Rascoe talks to Joan Kautz of Ironstone Vineyards, a winery in California, about the impact of Canadian tariffs on the U.S. alcohol industry.",
-        "pubDate": "2025-08-24T12:51:55",
+        "pubDate": "2025-08-24T12:51:55Z",
         "source": "npr.org"
       },
       {
         "title": "Call to end airport drop-off fees for blue badge holders",
         "link": "https://www.bbc.com/news/articles/cn5e1z6gz5yo?at_medium=RSS&at_campaign=rss",
         "description": "UK airports' charging policies are inconsistent and unfair, says Disabled Motoring UK.",
-        "pubDate": "2025-08-24T00:54:01",
+        "pubDate": "2025-08-24T00:54:01Z",
         "source": "bbc.com"
       },
       {
         "title": "Trump administration halts work on an almost-finished wind farm",
         "link": "https://www.npr.org/2025/08/23/nx-s1-5513919/trump-stops-offshore-wind-renewable-energy",
         "description": "The Revolution Wind farm was slated to start sending power to homes and businesses in Rhode Island and Connecticut starting next year.",
-        "pubDate": "2025-08-23T15:38:19",
+        "pubDate": "2025-08-23T15:38:19Z",
         "source": "npr.org"
       },
       {
         "title": "White House announces chipmaker Intel to give US government 10% stake",
         "link": "https://www.bbc.com/news/articles/cvg3zpdl3xdo?at_medium=RSS&at_campaign=rss",
         "description": "President Trump earlier said the company's CEO agreed to the deal in a recent meeting at the White House.",
-        "pubDate": "2025-08-22T22:27:03",
+        "pubDate": "2025-08-22T22:27:03Z",
         "source": "bbc.com"
       },
       {
         "title": "Canada to drop some of its retaliatory tariffs on the US",
         "link": "https://www.bbc.com/news/articles/c5yk9dqlvygo?at_medium=RSS&at_campaign=rss",
         "description": "The move comes after the two countries blew past a self-imposed deadline to reach a trade agreement.",
-        "pubDate": "2025-08-22T20:11:17",
+        "pubDate": "2025-08-22T20:11:17Z",
         "source": "bbc.com"
       },
       {
         "title": "Travellers warned of bank holiday disruption",
         "link": "https://www.bbc.com/news/articles/c1kzrxwjnryo?at_medium=RSS&at_campaign=rss",
         "description": "A rail strike and works are expected this weekend as millions begin their bank holiday getaways.",
-        "pubDate": "2025-08-22T17:32:43",
+        "pubDate": "2025-08-22T17:32:43Z",
         "source": "bbc.com"
       },
       {
         "title": "Brewdog co-founder leaves craft beer giant",
         "link": "https://www.bbc.com/news/articles/cg50p64rev3o?at_medium=RSS&at_campaign=rss",
         "description": "Martin Dickie, who founded the Ellon-based firm with James Watt in 2007, announced his decision in an email to staff.",
-        "pubDate": "2025-08-22T17:26:59",
+        "pubDate": "2025-08-22T17:26:59Z",
         "source": "bbc.com"
       },
       {
         "title": "Fed chair Powell boosts expectation of US rate cut",
         "link": "https://www.bbc.com/news/articles/c5ylwyx43x4o?at_medium=RSS&at_campaign=rss",
         "description": "Jerome Powell appeared to back a cut to borrowing rates and played down long term inflation risks in his annual speech at Jackson Hole.",
-        "pubDate": "2025-08-22T16:33:16",
+        "pubDate": "2025-08-22T16:33:16Z",
         "source": "bbc.com"
       },
       {
         "title": "Fed Chair Jerome Powell signals possible rate cut, sending stocks sharply higher",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5509941/jerome-powell-federal-reserve-interest-rates-jackson-hole",
         "description": "Federal Reserve chairman Jerome Powell signaled a possible interest rate cut in the months to come, sending stocks sharply higher.",
-        "pubDate": "2025-08-22T16:05:33",
+        "pubDate": "2025-08-22T16:05:33Z",
         "source": "npr.org"
       },
       {
         "title": "Royal Mail and DHL halt some US deliveries over tariffs",
         "link": "https://www.bbc.com/news/articles/cx2p17xypgko?at_medium=RSS&at_campaign=rss",
         "description": "Services including Royal Mail and  DHL say they are suspending deliveries until they have proper systems in place.",
-        "pubDate": "2025-08-22T15:38:48",
+        "pubDate": "2025-08-22T15:38:48Z",
         "source": "bbc.com"
       },
       {
         "title": "Revolution Beauty to 'reset' after sale falls through",
         "link": "https://www.bbc.com/news/articles/c36j2nxg202o?at_medium=RSS&at_campaign=rss",
         "description": "Co-founders Adam Minto and Tom Allsworth will return to the troubled brand after plummeting sales.",
-        "pubDate": "2025-08-22T14:47:57",
+        "pubDate": "2025-08-22T14:47:57Z",
         "source": "bbc.com"
       },
       {
         "title": "Assaults on public-facing workers should be specific offence, bosses say",
         "link": "https://www.bbc.com/news/articles/c79ljgx0el8o?at_medium=RSS&at_campaign=rss",
         "description": "The Institute of Customer Service says many are considering leaving their jobs as a result of abuse.",
-        "pubDate": "2025-08-22T14:31:05",
+        "pubDate": "2025-08-22T14:31:05Z",
         "source": "bbc.com"
       },
       {
         "title": "The shop making people laugh for nearly 100 years",
         "link": "https://www.bbc.com/news/videos/czjmn21r194o?at_medium=RSS&at_campaign=rss",
         "description": "Hull's iconic Dinsdale's joke shop has remained pretty much untouched for almost a century.",
-        "pubDate": "2025-08-22T10:10:22",
+        "pubDate": "2025-08-22T10:10:22Z",
         "source": "bbc.com"
       },
       {
         "title": "She's cared for America's elderly for decades. Trump wants her gone by Sept. 8",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5502439/trump-immigration-tps-health-care",
         "description": "The Trump administration has moved to end temporary protected status for immigrants from Honduras and other countries. Among them are health care workers tending to older and disabled people.",
-        "pubDate": "2025-08-22T09:00:00",
+        "pubDate": "2025-08-22T09:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "Home sales are ticking up — and more are coming to market",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5510058/housing-market-mortgage-rates-homebuilding",
         "description": "High mortgage rates cooled home sales over the last few years. But data released this week shows signs that things may be thawing a bit.",
-        "pubDate": "2025-08-22T09:00:00",
+        "pubDate": "2025-08-22T09:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "What happens when people stop trusting their government's economic data?",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5499343/what-happens-when-people-stop-trusting-their-governments-economic-data",
         "description": "What happens when people stop trusting their government's economic data? Planet Money reports on what happened in Greece.",
-        "pubDate": "2025-08-22T08:46:55",
+        "pubDate": "2025-08-22T08:46:55Z",
         "source": "npr.org"
       },
       {
         "title": "'I work full-time but can't afford school uniform'",
         "link": "https://www.bbc.com/news/articles/cj4w0l5krvxo?at_medium=RSS&at_campaign=rss",
         "description": "Parents using a free clothing bank say they are already making cut-backs to pay for schoolwear.",
-        "pubDate": "2025-08-22T08:30:12",
+        "pubDate": "2025-08-22T08:30:12Z",
         "source": "bbc.com"
       },
       {
         "title": "Trump backs down from 250% EU pharma tariff in deal",
         "link": "https://www.bbc.com/news/articles/ckgjwk8gze7o?at_medium=RSS&at_campaign=rss",
         "description": "The US and EU have released details of the new trade deal reducing tariffs between the two partners.",
-        "pubDate": "2025-08-22T07:23:04",
+        "pubDate": "2025-08-22T07:23:04Z",
         "source": "bbc.com"
       },
       {
         "title": "WH Smith shares tumble 42% after accounting blunder",
         "link": "https://www.bbc.com/news/articles/c3v363zr6kdo?at_medium=RSS&at_campaign=rss",
         "description": "The retailer has drafted in auditors to review the issue and slashed its profit guidance.",
-        "pubDate": "2025-08-22T05:56:16",
+        "pubDate": "2025-08-22T05:56:16Z",
         "source": "bbc.com"
       },
       {
         "title": "A Berlin garden of flavorsome herbs revives a monastic health tradition from the Middle Ages - AP News",
         "link": "https://news.google.com/rss/articles/CBMiqgFBVV95cUxQMlNoMjBuS2hkN1lsR1hRd05UWlpCVjQydmRwVXZWdmdvWDdXS3k3N0xjSmYzcUdQSW0xT0ZoR2ZNOEY5MFpqalRxNkhjaW9NTDRhcnlYREJJSTFZc1RIQjFRdTUxX2FVaEZ6UUlqcTdNQWpWM3NHRFhIRlZ4UUl3Nzd5LXcyTE5tVk5Zb3E5WVRTUmNTSldHb2JKR2c2RzZOMVhmVy01TmpPdw?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T05:18:00",
+        "pubDate": "2025-08-22T05:18:00Z",
         "source": "news.google.com"
       },
       {
         "title": "'Significant disruption' as CrossCountry trains cut",
         "link": "https://www.bbc.com/news/articles/cwy5vplw54jo?at_medium=RSS&at_campaign=rss",
         "description": "RMT members will walk out on Saturday and Monday, but Sunday trains could also be cancelled.",
-        "pubDate": "2025-08-22T05:10:50",
+        "pubDate": "2025-08-22T05:10:50Z",
         "source": "bbc.com"
-      },
-      {
-        "title": "New York Jets make trade for Phillips official and place Weaver on season-ending IR, cut Mathis - AP News",
-        "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxNWUFpY1BVQ3BmejJVdGEtRF9hOG82VXZjTVJYSkM5bVFjaEk3VmRWakRNMjZPQ1FUZXhtZWp4WnB5cFhXUHFzcjFIZ0FhUGxiMFZjcVk4SjFYQ2pwWGMyRmlTMlFrLXBHNkwyS1I4enBLNzJDR0lmXzlLNEpDM2Q0SUo1UkktUnpSUlF1dHFyaw?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T21:16:00",
-        "source": "news.google.com"
       },
       {
         "title": "Iowa Democrats consider bringing back lead off caucuses, even if it means going 'rogue' in 2028 - AP News",
         "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxNdlc5NzJla2xDSEtRbFFaY0l1Z1kwQXlHcC16dEN3WUI2bkE5UV9xSFJoYVhEbDF2aDhwYkxJV3E0NDNGZkNNTTZjZnpBcGRuWEthNndtN3k3akNqTTlfaThEYjdDSDJ6U0NfTExKZnpJdG5WOU11VXlNaVVtWHdWanluMWlnTnpEZUF2blJLRXZ4MnNxc0huR21YOA?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T19:02:00",
+        "pubDate": "2025-08-21T19:02:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Students face new cellphone restrictions in 17 states as school year begins - AP News",
         "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxOYkhpaFpxRGdnOFRFdk5YTFJlMVhCOUdIYm56NHpjcGJ1Z1dYWmhhUVdXZVEwZGlQVGhHVVFQTFl1ZElPbHkxc1lDb19DZGpmVE44RTIzZ2NsYktmZW1iOF95VmxRa2d2R1Z6LWMzSjZoSFpXZlJRaWRNNnBIc0FWcGtDTWt3UmJJeVl5YUhUOEt2MXpacmhlZjJjekZCU0ZWeVJXZmFn?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T15:34:00",
+        "pubDate": "2025-08-21T15:34:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Tesco meal deal price rises by 25p",
         "link": "https://www.bbc.com/news/articles/clyr7renp51o?at_medium=RSS&at_campaign=rss",
         "description": "The move by the UK's largest supermarket is the latest example of rising food prices.",
-        "pubDate": "2025-08-21T14:31:23",
+        "pubDate": "2025-08-21T14:31:23Z",
         "source": "bbc.com"
       },
       {
         "title": "Tube staff to strike over pay and work conditions",
         "link": "https://www.bbc.com/news/articles/cn728er5p1mo?at_medium=RSS&at_campaign=rss",
         "description": "RMT union members will strike from Friday 5 September for seven days.",
-        "pubDate": "2025-08-21T14:23:47",
+        "pubDate": "2025-08-21T14:23:47Z",
         "source": "bbc.com"
       },
       {
         "title": "Average five-year mortgage at lowest level since 2023",
         "link": "https://www.bbc.com/news/articles/cdd3qm7ly8ro?at_medium=RSS&at_campaign=rss",
         "description": "The average five-year fixed rate is now 4.99%, falling below 5% for the first time since 2023.",
-        "pubDate": "2025-08-21T14:22:51",
+        "pubDate": "2025-08-21T14:22:51Z",
         "source": "bbc.com"
       },
       {
         "title": "Foundation seeks charity partners for new projects",
         "link": "https://www.bbc.com/news/articles/cly7gd0wgq3o?at_medium=RSS&at_campaign=rss",
         "description": "Guernsey Community Foundation invites charities to collaborate on tackling living costs and housing.",
-        "pubDate": "2025-08-21T05:14:36",
+        "pubDate": "2025-08-21T05:14:36Z",
         "source": "bbc.com"
       },
       {
         "title": "County's 'secret' festival marks 25th anniversary",
         "link": "https://www.bbc.com/news/articles/cr5r793lvggo?at_medium=RSS&at_campaign=rss",
         "description": "The four-day Shambala Festival is set to welcome about 15,000 people to Northamptonshire.",
-        "pubDate": "2025-08-21T05:07:31",
+        "pubDate": "2025-08-21T05:07:31Z",
         "source": "bbc.com"
       },
       {
         "title": "Delta and United sued for selling 'window seats' without windows",
         "link": "https://www.bbc.com/news/articles/c754k7d0z51o?at_medium=RSS&at_campaign=rss",
         "description": "Delta and United are being sued over allegedly charging extra for seats next to a blank walls.",
-        "pubDate": "2025-08-21T02:57:04",
+        "pubDate": "2025-08-21T02:57:04Z",
         "source": "bbc.com"
       },
       {
         "title": "A look at those Trump has targeted in tactic of revoking security clearances - AP News",
         "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxNYWxwR1VpellpNkVOa2UzYXFJMU0xVWlzcmhzQVZoMEw4ZmZFeC1TbGw0TUZVNDZhZjEwN3NUOGl1LS00dE9oQmYtVkVoekttSzA5cXczWUpQMnEtTm81aFRHYkVMSXk1MVYzSzFlUC0tNE1tRnQ3ZmlYZ09KQVBzOUcxOXdkS3ZTQ1k2THU0Z2oyMHNlakFN?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T01:02:00",
+        "pubDate": "2025-08-21T01:02:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Denmark ending letter deliveries is a sign of the digital times",
         "link": "https://www.bbc.com/news/articles/c3v37plv2edo?at_medium=RSS&at_campaign=rss",
         "description": "PostNord blames sharply falling demand - will other post firms around the world follow suit?",
-        "pubDate": "2025-08-20T23:04:51",
+        "pubDate": "2025-08-20T23:04:51Z",
         "source": "bbc.com"
       },
       {
         "title": "Federal Reserve official says she won’t be ‘bullied’ by Trump into resigning - AP News",
         "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxOMUMzQmdkcEhEbzFVbzFxMEUyZk5zcWoyek4zMmJVM3ZMNnAzcjhuNWRtZW5vcFp3YWNKSldYVk53M1UwUDlsaTRNbWlhRmRKSVNsSlN6UmMtTGRsOE85NTJzdjROaHJqSENpYkIweDMxcXRlN2tzTTliQmRMZzVGNk1keHBKazNOTzlXMU03T00?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T22:19:00",
-        "source": "news.google.com"
-      },
-      {
-        "title": "Target CEO to step down amid company struggles - AP News",
-        "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxNMnNiX0ZidmN5MDNNbTE3Q05XclpaSlAySFJyUkJ0YlBsUXhjY051WTYzV0dQQTdGOTlNb0V3UFlhdGI0QzVqUS1CTVFvTWxtY25tT3JYcFdFdDFkS3lEUmpkOGQ3WmZNWGRSQVhaUm5ILUZoOUN1anlfX0dUR0FLamtUMllnYmNaZFJQbDh1bHdibm95VnVOSHJrSE9nSnpi?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T18:39:00",
+        "pubDate": "2025-08-20T22:19:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Sentencing for man who dodged 113 train tickets delayed",
         "link": "https://www.bbc.com/news/articles/cwy38zmvk04o?at_medium=RSS&at_campaign=rss",
         "description": "Charles Brohiri was granted bail despite clocking up £30,000 in penalty fares.",
-        "pubDate": "2025-08-20T17:02:28",
+        "pubDate": "2025-08-20T17:02:28Z",
         "source": "bbc.com"
       },
       {
         "title": "Government prepares to take over UK's third-largest steelworks",
         "link": "https://www.bbc.com/news/articles/cj0yd0829m4o?at_medium=RSS&at_campaign=rss",
         "description": "Managers have been lined up to take control in a bid to protect 1,500 jobs at the Yorkshire plant.",
-        "pubDate": "2025-08-20T16:36:07",
+        "pubDate": "2025-08-20T16:36:07Z",
         "source": "bbc.com"
       },
       {
         "title": "Foodbank manager surprised at high demand for service",
         "link": "https://www.bbc.com/news/articles/cjw6z53wl1lo?at_medium=RSS&at_campaign=rss",
         "description": "The new manager Gloucester Foodbank said she was unaware of how many people still need help.",
-        "pubDate": "2025-08-20T14:38:32",
+        "pubDate": "2025-08-20T14:38:32Z",
         "source": "bbc.com"
       },
       {
         "title": "Why are food prices still rising by so much?",
         "link": "https://www.bbc.com/news/articles/cyvn9z3y78lo?at_medium=RSS&at_campaign=rss",
         "description": "Food and drink prices have risen by 4.9% over the last year, according to ONS inflation data.",
-        "pubDate": "2025-08-20T14:00:07",
+        "pubDate": "2025-08-20T14:00:07Z",
         "source": "bbc.com"
       },
       {
         "title": "Business Daily",
         "link": "https://www.bbc.co.uk/sounds/play/w3ct6s2g?at_medium=RSS&at_campaign=rss",
         "description": "Thousands of firms have the certification, but some think the rules aren't strict enough",
-        "pubDate": "2025-08-14T08:03:00",
+        "pubDate": "2025-08-14T08:03:00Z",
         "source": "bbc.co.uk"
       },
       {
         "title": "'One video about a dress made me £6,000'",
         "link": "https://www.bbc.com/news/videos/c7vl1402lmdo?at_medium=RSS&at_campaign=rss",
         "description": "Single mum Roxanne Freeman has paid off her debt with her earnings as a TikTok content creator.",
-        "pubDate": "2025-08-13T15:42:57",
+        "pubDate": "2025-08-13T15:42:57Z",
         "source": "bbc.com"
       },
       {
         "title": "The UK car industry is at a tipping point - can it be saved?",
         "link": "https://www.bbc.com/news/articles/c23p028p200o?at_medium=RSS&at_campaign=rss",
         "description": "Tariffs, Brexit, pandemic havoc... All of this caused short-term disruption - but the impact concealed a deeper problem for the UK automotive industry",
-        "pubDate": "2025-08-12T23:00:58",
+        "pubDate": "2025-08-12T23:00:58Z",
         "source": "bbc.com"
       },
       {
         "title": "Inside Australia's billion-dollar bid to take on China's rare earth dominance",
         "link": "https://www.bbc.com/news/articles/cgm2z91mvlvo?at_medium=RSS&at_campaign=rss",
         "description": "Recent moves by Beijing have got businesses worried - and Australia is looking to offer an alternative.",
-        "pubDate": "2025-08-12T22:05:03",
+        "pubDate": "2025-08-12T22:05:03Z",
         "source": "bbc.com"
       },
       {
         "title": "China's unemployed young adults who are pretending to have jobs",
         "link": "https://www.bbc.com/news/articles/cdd3ep76g3go?at_medium=RSS&at_campaign=rss",
         "description": "With Chinese youth unemployment high, individuals are paying to go into offices and pretend to work.",
-        "pubDate": "2025-08-11T01:50:13",
+        "pubDate": "2025-08-11T01:50:13Z",
         "source": "bbc.com"
       },
       {
         "title": "Why firms are merging HR and IT departments",
         "link": "https://www.bbc.com/news/articles/cy0w8gvq84xo?at_medium=RSS&at_campaign=rss",
         "description": "The emergence of AI is spurring some firms to make their HR and IT departments work closer together.",
-        "pubDate": "2025-08-07T23:13:47",
+        "pubDate": "2025-08-07T23:13:47Z",
         "source": "bbc.com"
       },
       {
         "title": "How Europe is vying for rare earth independence from China",
         "link": "https://www.bbc.com/news/articles/cm2zp6m4gy7o?at_medium=RSS&at_campaign=rss",
         "description": "The EU is aiming to increase its own production of rare earth metals, led by a facility in France.",
-        "pubDate": "2025-08-06T23:02:31",
+        "pubDate": "2025-08-06T23:02:31Z",
         "source": "bbc.com"
       },
       {
         "title": "Will new greener brake pads be more expensive?",
         "link": "https://www.bbc.com/news/articles/cp3l4qz1l9qo?at_medium=RSS&at_campaign=rss",
         "description": "Automotive industry will have to change techniques and materials as new EU rules come into force in 2026",
-        "pubDate": "2025-08-04T23:06:39",
+        "pubDate": "2025-08-04T23:06:39Z",
         "source": "bbc.com"
       },
       {
         "title": "Trump's global tariffs 'victory' may well come at a high price",
         "link": "https://www.bbc.com/news/articles/c0l6g13rlwko?at_medium=RSS&at_campaign=rss",
         "description": "The US president considers it a win - but if this all triggers a foundational realignment, the results may not break in his favour",
-        "pubDate": "2025-07-31T23:01:04",
+        "pubDate": "2025-07-31T23:01:04Z",
         "source": "bbc.com"
       },
       {
         "title": "Judge bars ICE from immediately taking Abrego Garcia into custody if he’s released from jail - AP News",
         "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxPbmkzbmtRRWxabmRadlRFTlVVQ2JZWnFsUzdPZnpUemVMVk5ZTDMtQXQ1bjRndlVOVElzaHktUkVZMzFqemZSaFEtOG9UN2Myamd0d0Z0V1hjTEFDTWc5bFlWeFRUNGFCWUVFZzdoWkNqM19KMGhyN3R6LVNUVW9BWUF6dkVZQWV0OFVCdU1iMDFNSWVieml5NXFwVWw?oc=5",
         "description": "",
-        "pubDate": "2025-07-23T07:00:00",
+        "pubDate": "2025-07-23T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "An Omaha food plant owner says he followed the rules for hiring immigrants. It was raided anyway. - AP News",
         "link": "https://news.google.com/rss/articles/CBMingFBVV95cUxQaEVFZ0J1eFE4YW4xN3pMMkJ2ZGUtcFdQazVXVjJac3lQOFN6MzFFbl9ZV2FzOGdPSmU1eFdxM3NKV2JXMVd2UzR1WFRhWjQ3anh0NHlONFRTNFBKS0JKSlRycFRZLXJZUWl2NzUyYnoyNTM1dG5BeThacjNKMm5RdWVoSFN0QmdTc0Z1UHJzeEhKOXRFY0pkM2RCUGxtQQ?oc=5",
         "description": "",
-        "pubDate": "2025-06-11T07:00:00",
+        "pubDate": "2025-06-11T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "China's electric cars are becoming slicker and cheaper - but is there a deeper cost?",
         "link": "https://www.bbc.com/news/articles/cy8d4v69jw6o?at_medium=RSS&at_campaign=rss",
         "description": "The future for EVs will inevitably involve China. But where does that leave the UK and Europe markets – and what of the questions around national security?",
-        "pubDate": "2025-06-09T23:04:10",
+        "pubDate": "2025-06-09T23:04:10Z",
         "source": "bbc.com"
+      },
+      {
+        "title": "The secretive US factory that lays bare the contradiction in Trump's America First plan",
+        "link": "https://www.bbc.com/news/articles/cwywj0zgzwxo?at_medium=RSS&at_campaign=rss",
+        "description": "An exclusive look inside the closely guarded factory the president wants to become a foundation stone for a US golden age.",
+        "pubDate": "2025-05-18T21:55:21Z",
+        "source": "bbc.com"
+      },
+      {
+        "title": "Here’s a look inside Donald Trump’s $355 million civil fraud verdict - AP News",
+        "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxOdGxEQVdEcjJ2UU1Zd25FM0pUVGF0VXpSaUpRcUdtSnczbUcwWEhQWUdmVVBkOUprU2ZMXzVfbFNUUjkyNm9mNkVDUFp6ZG95OUQ4VTg3cXpzTy1ZWUIxM0t1dFJJZkJmazFrdkpCU2tza0tFeUp0VkdBUC1Sd2dYSlNPUmJoWGktcEtxUHJPQUZ6S05FU2ZoX2VLanlxUjRKWVZWMw?oc=5",
+        "description": "",
+        "pubDate": "2024-02-17T08:00:00Z",
+        "source": "news.google.com"
       }
     ],
     "Culture": [
@@ -1766,350 +1766,350 @@
         "title": "Fans across the country raise their voices at 'KPop Demon Hunters' singalongs",
         "link": "https://www.npr.org/2025/08/24/nx-s1-5509691/kpop-demon-hunters-singalong-huntrix-saja-boys-netflix",
         "description": "Netflix's wildly popular movie about a fictitious all-girl rock band is hitting nearly 1,800 movie theaters around the country this weekend as a singalong version.",
-        "pubDate": "2025-08-24T09:00:00",
+        "pubDate": "2025-08-24T09:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "Bands boycott music festival after group's set 'cut off'",
         "link": "https://www.bbc.com/news/articles/c1jnyrk07ndo?at_medium=RSS&at_campaign=rss",
         "description": "The Last Dinner Party, Cliffords and The Academic refuse to perform at Victorious Festival.",
-        "pubDate": "2025-08-24T08:20:42",
+        "pubDate": "2025-08-24T08:20:42Z",
         "source": "bbc.com"
       },
       {
         "title": "Pierce Brosnan felt 'huge responsibility' towards Thursday Murder Club fans",
         "link": "https://www.bbc.com/news/articles/cn47gkpywk2o?at_medium=RSS&at_campaign=rss",
         "description": "Dame Helen Mirren, Celia Imrie and Sir Ben Kingsley round out a quartet that unites to investigate murder.",
-        "pubDate": "2025-08-24T04:02:18",
+        "pubDate": "2025-08-24T04:02:18Z",
         "source": "bbc.com"
       },
       {
         "title": "Were masterpieces worth £100m really found under a pensioner's bed?",
         "link": "https://www.bbc.com/news/articles/cz932w11qwdo?at_medium=RSS&at_campaign=rss",
         "description": "Three works attributed to Malevich are on show in Bucharest but an art scholar says the story behind them is problematic.",
-        "pubDate": "2025-08-24T00:43:05",
+        "pubDate": "2025-08-24T00:43:05Z",
         "source": "bbc.com"
       },
       {
         "title": "First trans comedian to win Edinburgh comedy award",
         "link": "https://www.bbc.com/news/articles/cvgvz090195o?at_medium=RSS&at_campaign=rss",
         "description": "Sam Nicoresti took the esteemed award for their show Baby Doomer, while Ayoade Bamgboye won the award for best newcomer.",
-        "pubDate": "2025-08-23T13:57:13",
+        "pubDate": "2025-08-23T13:57:13Z",
         "source": "bbc.com"
       },
       {
         "title": "Actress Sue Johnston to return to Brookside",
         "link": "https://www.bbc.com/news/articles/cr74pv25n88o?at_medium=RSS&at_campaign=rss",
         "description": "The acclaimed actress is set to return to Brookside Close for a one-of special episode this year.",
-        "pubDate": "2025-08-23T06:02:00",
+        "pubDate": "2025-08-23T06:02:00Z",
         "source": "bbc.com"
       },
       {
         "title": "Fans loved her new album. The thing was, she hadn't released one",
         "link": "https://www.bbc.com/news/articles/clydz8d03dvo?at_medium=RSS&at_campaign=rss",
         "description": "Artists on the mystery of being targeted by fraudsters releasing \"AI slop\" songs in their name.",
-        "pubDate": "2025-08-22T23:12:40",
+        "pubDate": "2025-08-22T23:12:40Z",
         "source": "bbc.com"
       },
       {
         "title": "Anime fans hate live-action remakes - here's why studios still keep making them",
         "link": "https://www.bbc.com/news/articles/cy8jl9wvdlno?at_medium=RSS&at_campaign=rss",
         "description": "Beloved anime series Solo Leveling is the latest of the genre to be turned into a live-action remake by Netflix.",
-        "pubDate": "2025-08-22T22:03:38",
+        "pubDate": "2025-08-22T22:03:38Z",
         "source": "bbc.com"
       },
       {
         "title": "Chappell Roan slays Reading Festival with fairytale-themed set",
         "link": "https://www.bbc.com/news/articles/cr74p245zdlo?at_medium=RSS&at_campaign=rss",
         "description": "The US star took to the stage on Friday night, and was almost drowned out by her devoted fans.",
-        "pubDate": "2025-08-22T21:26:47",
+        "pubDate": "2025-08-22T21:26:47Z",
         "source": "bbc.com"
       },
       {
         "title": "She travelled eight hours by bus for violin lessons. Now she's playing Wembley with Coldplay",
         "link": "https://www.bbc.com/news/articles/c93de1y9nl5o?at_medium=RSS&at_campaign=rss",
         "description": "Musician Pathrycia Mendonça will play with the band as part of Venezuela's Simón Bolívar Symphony Orchestra.",
-        "pubDate": "2025-08-22T15:59:13",
+        "pubDate": "2025-08-22T15:59:13Z",
         "source": "bbc.com"
       },
       {
         "title": "'Weapons' exposes the dark underbelly of American suburbia",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5507122/weapons-review",
         "description": "Small-town life is upended when 17 schoolchildren suddenly vanish without explanation in the middle of the night.",
-        "pubDate": "2025-08-22T15:49:17",
+        "pubDate": "2025-08-22T15:49:17Z",
         "source": "npr.org"
       },
       {
         "title": "Remembering British actor Terence Stamp",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5511161/remembering-british-actor-terence-stamp",
         "description": "Stamp, who died Aug. 17, was part of a wave of working-class British actors who came up in the 1960s. His films include",
-        "pubDate": "2025-08-22T14:36:40",
+        "pubDate": "2025-08-22T14:36:40Z",
         "source": "npr.org"
       },
       {
         "title": "Daniel Dae Kim is still waiting for his rom-com moment. In the meantime, there’s ‘Butterfly’ - AP News",
         "link": "https://news.google.com/rss/articles/CBMimgFBVV95cUxPWXVPWXFMaXJWTy1VS2lCZnVIcm5KNXJjOWdfa3Y4MUNtYXhuaHlmYzVmX2xycjNfbDl0UDdYakVVX25xVm1vcnNyRVAxazFGaC01U0hoWTVYX3J5SDJRby1IaFYwRUd5RXcxeU1admU2MjZoX0VjdWt5aDZFbTNmV1Fmc3M1UmY5eUtmNGlyRTV0dlpMTWhicUtB?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T14:20:00",
+        "pubDate": "2025-08-22T14:20:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Noel Clarke loses libel case against the Guardian",
         "link": "https://www.bbc.com/news/articles/cwy33g0lelno?at_medium=RSS&at_campaign=rss",
         "description": "The award-winning actor sued the newspaper's publisher for printing allegations of sexual misconduct.",
-        "pubDate": "2025-08-22T13:53:42",
+        "pubDate": "2025-08-22T13:53:42Z",
         "source": "bbc.com"
       },
       {
         "title": "Spinal Tap 2 spotted being filmed at Stonehenge",
         "link": "https://www.bbc.com/news/articles/c7765lyenlvo?at_medium=RSS&at_campaign=rss",
         "description": "The ancient monument has been closing early this week to allow filming of the sequel to take place.",
-        "pubDate": "2025-08-22T13:00:13",
+        "pubDate": "2025-08-22T13:00:13Z",
         "source": "bbc.com"
       },
       {
         "title": "A box office record-setter you've never heard of and more in theaters this weekend",
         "link": "https://www.npr.org/2025/08/22/nx-s1-5508092/ne-zha-2-lurker-honey-dont-in-theaters-this-weekend",
         "description": "",
-        "pubDate": "2025-08-22T10:00:00",
+        "pubDate": "2025-08-22T10:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "Karen Gillan joins the cast of Highlander reboot",
         "link": "https://www.bbc.com/news/articles/cq87gn3q0yvo?at_medium=RSS&at_campaign=rss",
         "description": "The Scottish actress will star alongside former Superman actor Henry Cavill in a reboot of the classic 80s movie.",
-        "pubDate": "2025-08-22T09:45:41",
+        "pubDate": "2025-08-22T09:45:41Z",
         "source": "bbc.com"
       },
       {
         "title": "Mastodon guitarist Hinds dies in motorcycle crash",
         "link": "https://www.bbc.com/news/articles/cp8968vdlp0o?at_medium=RSS&at_campaign=rss",
         "description": "The 51-year-old, who left the band earlier this year, died in a collision in Atlanta, US.",
-        "pubDate": "2025-08-22T08:20:26",
+        "pubDate": "2025-08-22T08:20:26Z",
         "source": "bbc.com"
       },
       {
         "title": "Lil Nas X arrested and taken to hospital after wandering LA streets in underwear",
         "link": "https://www.bbc.com/news/articles/cgm2ep3eym7o?at_medium=RSS&at_campaign=rss",
         "description": "The LAPD allege the singer \"charged\" at them and was placed under arrest on suspicion of battery.",
-        "pubDate": "2025-08-22T06:16:02",
+        "pubDate": "2025-08-22T06:16:02Z",
         "source": "bbc.com"
       },
       {
         "title": "Billy Connolly says Elton John inspired new artwork",
         "link": "https://www.bbc.com/news/articles/c7vlq1v2v9ro?at_medium=RSS&at_campaign=rss",
         "description": "Sir Billy has released four new artworks recalling some of the fondest memories from his life.",
-        "pubDate": "2025-08-22T05:17:29",
+        "pubDate": "2025-08-22T05:17:29Z",
         "source": "bbc.com"
       },
       {
         "title": "Will that sparked Shakespeare family row found",
         "link": "https://www.bbc.com/news/articles/c987kjg04n5o?at_medium=RSS&at_campaign=rss",
         "description": "The row was over William Shakespeare's grand Stratford-upon-Avon home in Warwickshire.",
-        "pubDate": "2025-08-22T05:02:13",
+        "pubDate": "2025-08-22T05:02:13Z",
         "source": "bbc.com"
       },
       {
         "title": "BBC confirms Celebrity Traitors will air in October",
         "link": "https://www.bbc.com/news/articles/c8ry41v6mllo?at_medium=RSS&at_campaign=rss",
         "description": "About 19 famous faces will gather in the Scottish Highlands for the chance to win up to £100,000.",
-        "pubDate": "2025-08-21T18:41:08",
+        "pubDate": "2025-08-21T18:41:08Z",
         "source": "bbc.com"
       },
       {
         "title": "Tyla learns how to prep for Notting Hill Carnival",
         "link": "https://www.bbc.com/news/videos/cz93qky9qlqo?at_medium=RSS&at_campaign=rss",
         "description": "Radio 1Xtra presenter Nadia Jae shares her top tips for Notting Hill Carnival with singer Tyla.",
-        "pubDate": "2025-08-21T13:43:40",
+        "pubDate": "2025-08-21T13:43:40Z",
         "source": "bbc.com"
       },
       {
         "title": "Pitt is hoping a little continuity can go a long way after second-half collapse last season - AP News",
         "link": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxOaThIYUkyejZMT05xZFZuT3VHVmk1UDlzX0VvRmhMbC16QTJjT2RBQ2ZxZWIxOFJIRHBfd0RNUXFoYXc4Y3Zqb0w2MGtPbmZXUlJ6d21neUt0cmtxRzctODBQMHRIWnpkUG1haVpaSTJ6T1FSbXdpY2JwSHByQzlVLUhBeG9rQlJ4?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T10:10:00",
+        "pubDate": "2025-08-21T10:10:00Z",
         "source": "news.google.com"
       },
       {
         "title": "In 'Lurker' a social striver squirms his way into a star's inner circle",
         "link": "https://www.npr.org/2025/08/21/nx-s1-5503422/lurker-movie-review",
         "description": "This new film about a fan who gets close with an up-and-coming pop star lingers on the ways a relationship that might seem parasitic is closer to symbiotic.",
-        "pubDate": "2025-08-21T10:00:00",
+        "pubDate": "2025-08-21T10:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "The cultural significance of Sweden’s moving church - AP News",
         "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxNOE1uNENaeHVqR2lEWXViTkwyd2hQdk1HUkNtVWFJdlpRX3YtVmRGQ0hWa3hVMW5JUnVrY0JGa0xOVFhJVTdfeFRUR3BPUUN0MWlfWTktNWdiU1RjR3U4eENXRldSVFN2Q1pkaWhhTV9UWWQwVnJXck5aMXZlUWJFNlp5MUlPNF9UT1I2cUFpQkZSeWJ3WGRDT29KWWE1Y1hNUGRZS2Fza01UZ2dj?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T07:46:00",
+        "pubDate": "2025-08-21T07:46:00Z",
         "source": "news.google.com"
       },
       {
         "title": "‘Boots on the Ground’ viral dance highlights Black trail ride culture - AP News",
         "link": "https://news.google.com/rss/articles/CBMiwwFBVV95cUxNZUdaaFhMMXVoNnpJdjR0bl82U083amcyNENTcU1qZlhtNElRcUtnYVluQ0czdU9ndTUxelE4TmtmVHBIYWNudFhvVGdhZ1ZLdEZ1bHlRcm9QTkNNLWtxbG1VNUJpQktteTJ3RFdLbmtqVk01MEhQdkpWbER6akNYakVIdWU5M0h5WXVMcUxkR2JUZnllQm4xMm14RFMwMnkyU2I1OFIyV1pjbk9tbVFfdF9peEd2NnpJR0tOckRUdm1Wc2c?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T09:45:00",
+        "pubDate": "2025-08-20T09:45:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Trump says no to US troops in Ukraine - AP News",
         "link": "https://news.google.com/rss/articles/CBMia0FVX3lxTFBnd19OMnVqVk02Z2tGYXNpZTBiTDh1YTN1dnZFaGxheHBVMjc5VzJFRnNMSmFaWUNjWTRsQklHM21oOGY2eXRTTDJzcG1uNWFHQVBvMjhnRlQ2Mi1JY3lIaVlKQi1xakVNeXlj?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T01:25:00",
+        "pubDate": "2025-08-20T01:25:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Downton Abbey 'iconic' props and costumes up for auction",
         "link": "https://www.bbc.com/news/videos/c3dpzre97j4o?at_medium=RSS&at_campaign=rss",
         "description": "Props, costumes and set pieces from the popular British historical drama Downton Abbey are being auctioned for charity in London.",
-        "pubDate": "2025-08-19T18:51:43",
+        "pubDate": "2025-08-19T18:51:43Z",
         "source": "bbc.com"
       },
       {
         "title": "With 'Highest 2 Lowest,' Spike Lee puts a hip-hop spin on Kurosawa's 1963 classic",
         "link": "https://www.npr.org/2025/08/19/nx-s1-5503407/with-highest-2-lowest-spike-lee-puts-a-hip-hop-spin-on-kurosawas-1963-classic",
         "description": "Lee's new film centers on a music mogul who faces a moral dilemma when kidnappers mistakenly hold his friend's son ransom instead of his own: Will he risk it all to save a child who isn't his?",
-        "pubDate": "2025-08-19T17:27:55",
+        "pubDate": "2025-08-19T17:27:55Z",
         "source": "npr.org"
       },
       {
         "title": "Watch: Filming of new Harry Potter series spotted in London",
         "link": "https://www.bbc.com/news/videos/ceqyv7wr9nlo?at_medium=RSS&at_campaign=rss",
         "description": "Actors including Dominic McLaughlin and Nick Frost, who play Harry and Hagrid, are spotted in Southwark.",
-        "pubDate": "2025-08-19T14:38:00",
+        "pubDate": "2025-08-19T14:38:00Z",
         "source": "bbc.com"
       },
       {
         "title": "'Can't stop. Won't stop': Documentary filmmakers face federal funding shortfall",
         "link": "https://www.npr.org/2025/08/18/nx-s1-5490964/documentary-funding-cpb-pbs",
         "description": "PBS has been a home for independent documentaries for more than 50 years. But with the closure of the Corporation for Public Broadcasting, nonfiction storytellers have to figure out a way forward.",
-        "pubDate": "2025-08-18T14:00:00",
+        "pubDate": "2025-08-18T14:00:00Z",
         "source": "npr.org"
       },
       {
         "title": "From Sir Sean with love: The legacy that is helping young filmmakers",
         "link": "https://www.bbc.com/news/articles/cpdj660j94go?at_medium=RSS&at_campaign=rss",
         "description": "A foundation set up in Sir Sean's name helps give young people a start in the film industry.",
-        "pubDate": "2025-08-18T05:12:01",
+        "pubDate": "2025-08-18T05:12:01Z",
         "source": "bbc.com"
       },
       {
         "title": "Terence Stamp, '60s British film legend and star of 'Superman,' dies at 87",
         "link": "https://www.npr.org/2025/08/18/nx-s1-5505466/actor-terence-stamp-dies",
         "description": "The English actor was best known for starring as the arch-villain in the original",
-        "pubDate": "2025-08-18T04:10:45",
+        "pubDate": "2025-08-18T04:10:45Z",
         "source": "npr.org"
       },
       {
         "title": "Why are there so many movies about the movies?",
         "link": "https://www.npr.org/2025/08/17/nx-s1-5500522/why-are-there-so-many-movies-about-the-movies",
         "description": "NPR's film critic Bob Mondello and",
-        "pubDate": "2025-08-17T21:05:58",
+        "pubDate": "2025-08-17T21:05:58Z",
         "source": "npr.org"
       },
       {
         "title": "'Your Favorite Scary Movie' is a new history of the Scream franchise",
         "link": "https://www.npr.org/2025/08/17/nx-s1-5314940/your-favorite-scary-movie-is-a-new-history-of-the-scream-franchise",
         "description": "NPR's Ayesha Rascoe asks Ashley Cullins about the \"Scream\" franchise. Cullins writes about it in her book \"Your Favorite Scary Movie.\"",
-        "pubDate": "2025-08-17T13:02:08",
+        "pubDate": "2025-08-17T13:02:08Z",
         "source": "npr.org"
       },
       {
         "title": "Sugar Hut, spray tans, stilettos: Towie turns 15",
         "link": "https://www.bbc.com/news/articles/c98l693gylro?at_medium=RSS&at_campaign=rss",
         "description": "Love it or hate it, there is no denying that The Only Way is Essex thrust Essex into the spotlight.",
-        "pubDate": "2025-08-17T05:30:33",
+        "pubDate": "2025-08-17T05:30:33Z",
         "source": "bbc.com"
       },
       {
         "title": "Topshop returns to the High Street, but can it get its cool back?",
         "link": "https://www.bbc.com/news/articles/ckgl4w1zkypo?at_medium=RSS&at_campaign=rss",
         "description": "For many, the stores defined their childhood. Now the retailer says it is reopening them, and held its first catwalk for years on Saturday.",
-        "pubDate": "2025-08-16T17:42:42",
+        "pubDate": "2025-08-16T17:42:42Z",
         "source": "bbc.com"
       },
       {
         "title": "Blackpink: K-pop band make 'epic Wembley dream' come true",
         "link": "https://www.bbc.com/news/articles/c36jz730114o?at_medium=RSS&at_campaign=rss",
         "description": "The quartet have become the first Korean girl group to headline a concert at London's Wembley Stadium.",
-        "pubDate": "2025-08-16T01:20:20",
+        "pubDate": "2025-08-16T01:20:20Z",
         "source": "bbc.com"
       },
       {
         "title": "Ted Lasso's Nick Mohammed just can't stay away from Richmond",
         "link": "https://www.bbc.com/news/videos/cd9jkyx3lygo?at_medium=RSS&at_campaign=rss",
         "description": "The actor and comedian joins Josh Widdicombe in the Radio 2 studio for a chat.",
-        "pubDate": "2025-08-14T16:08:59",
+        "pubDate": "2025-08-14T16:08:59Z",
         "source": "bbc.com"
       },
       {
         "title": "'One-take wonder': David Jason on that  iconic chandelier scene",
         "link": "https://www.bbc.com/news/videos/ce93dv90k9ko?at_medium=RSS&at_campaign=rss",
         "description": "The British actor who portrayed Del Boy in the TV show Only Fools and Horses told BBC Breakfast about how the backstage crew reacted to the show's famous chandelier scene",
-        "pubDate": "2025-08-14T10:08:20",
+        "pubDate": "2025-08-14T10:08:20Z",
         "source": "bbc.com"
       },
       {
         "title": "Does anyone still send postcards?",
         "link": "https://www.bbc.com/news/videos/c627nwpg5q9o?at_medium=RSS&at_campaign=rss",
         "description": "The BBC speaks to people on Hastings Beach to find out whether postcards are making a comeback.",
-        "pubDate": "2025-08-12T09:35:52",
+        "pubDate": "2025-08-12T09:35:52Z",
         "source": "bbc.com"
       },
       {
         "title": "Mexican-American designer apologizes for Adidas sandal design accused of cultural appropriation - AP News",
         "link": "https://news.google.com/rss/articles/CBMitgFBVV95cUxNcEZmUmZSYkhJQ3k1Q1NVSDY4aHZ1Rm9DVy1PSjZaRzI5SGVUN3pKQ1lPenlGeU9ZcUZpWEVwb0gzRTh3WjlnX0wwaXl1R1pDaHA2RTlpMG42a09yTWFpR0RRV01PR19sOFBHRmx0LUMyTE1QbkZKb0xmUnpGc2hPb2s5UjBxTTdnc21jYlpDZDdqZGpXSXBjWFhDd1VnaUlYREJoMi1PTTBzd1YwMkFCS2hkMDZ3QQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-12T07:00:00",
+        "pubDate": "2025-08-12T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Bugs are popular pets in nature-loving Japan, buzzing with lessons about ecology and species - AP News",
         "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxPZXFVRzN2Y0hqMTJaMlU4WmNxTE05N1U2TmtGVHpBRTNwSDhSLW1iVkw2UU40Tng2b1JWc21YNnJ4OUZuVkxfVGc2dF9UTzUxblB1b0hSR29QQ2R0cDFINEdhQnRSaVNjOGNnN2Y1M3A4a3dqc3NtdV9sUy04d0xzUjR1cmNJYjZ0LW1RN3dLa05NWmY4LUNROHdxdmdfRXln?oc=5",
         "description": "",
-        "pubDate": "2025-08-11T07:00:00",
+        "pubDate": "2025-08-11T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Eve doesn’t think about her giant impact on hip-hop culture - AP News",
         "link": "https://news.google.com/rss/articles/CBMitwFBVV95cUxOY250c0FiYU55TDRTM0U3dXI0UHFOQzlHYUxneWVyV1VUejEyZTZ5RnNaU0xDVlRTS2g5dzJVUF8wX2J0OUJlTlp6MUdPNUdvajd3Y0FXNFhwYW91bDhSNkRybE9aLTE0ZWtiVVJuejZ0cHFoMlMzdWkwdXlvajJ1VnJJR3RMV0djdjRCeGFiM0V0cGt3c2NjNGtsZENLVTV0MzNmWDYwVUlXNUR0blFaUkpWSEg0Szg?oc=5",
         "description": "",
-        "pubDate": "2025-08-11T07:00:00",
+        "pubDate": "2025-08-11T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Watch: Royal Albert Hall hosts first overnight Prom in decades",
         "link": "https://www.bbc.com/news/videos/cx2747j72g6o?at_medium=RSS&at_campaign=rss",
         "description": "\"The energy in the room has just been so incredible\" organist and curator Anna Lapwood told the BBC.",
-        "pubDate": "2025-08-09T08:59:36",
+        "pubDate": "2025-08-09T08:59:36Z",
         "source": "bbc.com"
       },
       {
         "title": "Mexican authorities accuse Adidas of cultural appropriation in their sandal design - AP News",
         "link": "https://news.google.com/rss/articles/CBMizAFBVV95cUxPdzJyZTMtcXFJaUVRU0dfMHJsUUV2alFiR3dNd3JseGhaVFF2emRhVDBocjlpd05SdGVnbkt4U3pQWEdyRFNtOE5uZ2J3aDU0UGFXMGVuSEdOQlJFckhGcGVFUm9HMlR6NWRRWjcwWTVNTGdmTEhhTEdnaXQzemt4aVlLYUhtYnBLM0JuZnFVVWF1N2hZaUl4UFNMa2RaLW9qZWJ4dmRHX185UjFHeTNlSV90UGJjY3N4Q1JsQThlSG1qck1KVExHdGc1VkQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-09T07:00:00",
+        "pubDate": "2025-08-09T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Confederate statues in DC area to be restored and replaced in line with Trump's executive order - AP News",
         "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxOTmVPbzRNSDVvNlhFOU5HY3hzRzNKS2poWFpVeFRkd0xQdUpnRk13ZWZ4LUVYTEJhS3BqRkNKUzJBeXlvV242elRPZkR4MVFFRU1wcmVtRHJsSVFZODdNX3BTemZOXzBEVTgyZFhkOTR2Y2ZLQmZHN19SbmswbnpSVkthV2cyOU9Fa2J2TFR4S1U4UWdqMTBVa3hYeU0zVFlIUTlVSG1jendTZHFTVDJMWjRn?oc=5",
         "description": "",
-        "pubDate": "2025-08-05T07:00:00",
+        "pubDate": "2025-08-05T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Matt Rogers talks bringing zeitgeisty Las Culturistas Awards to TV for the 1st time - AP News",
         "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxNNDUzSWpwZG1ZUERKaVFTRlJyZGRaUnFPYUpHY2Z3RHRiRVRES09HRUpiZGI5QnJLY3lnaHp6dUlJVHV0LTlmczgzYVJNSVAxOGtxUGlxWEQ1aTE5a0t5WEpvel9GcE9vZmp1ekdqMEJTXzRJWVE0ZFprN3J2dHY3U0U1YWpScldCc1E1Wkp2eWZOdFNJMFRaMnBmUXZNSFk1VW1HZEk0RFBkbkMyUkk5c2Z3?oc=5",
         "description": "",
-        "pubDate": "2025-08-01T07:00:00",
+        "pubDate": "2025-08-01T07:00:00Z",
         "source": "news.google.com"
       },
       {
         "title": "Burial site of the Chancay culture found in the outskirts of Lima - AP News",
         "link": "https://news.google.com/rss/articles/CBMiwAFBVV95cUxOcnVvRG1rM01ENV90WjhNd2J5OEZacWdxaEpjTWRmdkIwM2NqSVhHZWh2UFRGQWxSWEZnbF9Bb3k4T0h2dnpUdjlnSjJ1cDc3d1R4R3VuMjJ5QzhJeDBvQ1hLMm5UV1hVcnJlZnFZUTdiOGM0Rm1ZZkUtV0JKczFtdGdvTm5FeTlMVkJaNnRsRGxQOWlKTzFYZTlueURGWEN0STBXWmlhLWxaX3Nvdk9RSlVMWkdxaHQyMW5pMVdPLWQ?oc=5",
         "description": "",
-        "pubDate": "2025-07-31T07:00:00",
+        "pubDate": "2025-07-31T07:00:00Z",
         "source": "news.google.com"
       }
     ]

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -87,11 +87,16 @@ def extract_items(xml_data: bytes) -> list:
         pub_date = parse_pub_date(pub)
         netloc = urlparse(link).netloc
         source = netloc.replace('www.', '') if netloc else ''
+        # ``datetime.isoformat`` omits a timezone designator when the object is
+        # naïve.  Some browsers (notably Safari) refuse to parse such strings via
+        # ``new Date(...)`` which then causes the client script to fail when
+        # formatting the publication date.  Mark the timestamp explicitly as UTC
+        # with a trailing ``Z`` to ensure cross‑browser compatibility.
         items.append({
             'title': html.unescape(title.strip()),
             'link': link.strip(),
             'description': html.unescape(description_text.strip()),
-            'pubDate': pub_date.isoformat(),
+            'pubDate': pub_date.replace(microsecond=0).isoformat() + 'Z',
             'source': source
         })
     return items

--- a/script.js
+++ b/script.js
@@ -91,9 +91,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const meta = document.createElement('div');
     meta.className = 'article-meta';
     const date = new Date(article.pubDate);
-    meta.textContent = `${article.source || ''} • ${date.toLocaleString(undefined, {
-      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
-    })}`;
+    const dateStr = isNaN(date)
+      ? ''
+      : date.toLocaleString(undefined, {
+          year: 'numeric', month: 'short', day: 'numeric',
+          hour: '2-digit', minute: '2-digit'
+        });
+    meta.textContent = `${article.source || ''}${dateStr ? ` • ${dateStr}` : ''}`;
     const desc = document.createElement('p');
     desc.className = 'article-description';
     // Truncate long descriptions to 200 characters


### PR DESCRIPTION
## Summary
- Ensure `pubDate` strings include a trailing `Z` so browsers can parse timestamps reliably
- Guard news rendering against invalid dates in the client script
- Regenerate `data/news.json` with UTC timestamps

## Testing
- `python fetch_news.py`
- `python -m py_compile fetch_news.py`
- `python -m json.tool data/news.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68ab49fdf438832d92af9b11ea815b87