### PR TITLE
Fix update workflow paths after repository restructure

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,7 @@
+---
 name: Update News
 
-on:
+'on':
   schedule:
     # Run once every 24 hours at midnight UTC
     - cron: '0 0 * * *'
@@ -25,12 +26,10 @@ jobs:
 
       - name: Fetch and update news
         run: |
-          cd news_site
           python fetch_news.py
 
       - name: Commit and push changes
         run: |
-          cd news_site
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/news.json


### PR DESCRIPTION
## Summary
- remove outdated `news_site` directory references in update workflow
- add YAML document start and quote `on` to satisfy yamllint

## Testing
- `python fetch_news.py >/tmp/fetch.log && ls -l data/news.json | tail -n 1`
- `yamllint -v .github/workflows/update.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ab508b5a60832d9d596d8f96ec6e62