### PR TITLE
Update news refresh interval to every 10 minutes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,8 +3,8 @@ name: Update News
 
 'on':
   schedule:
-    # Run once every 24 hours at midnight UTC
-    - cron: '0 0 * * *'
+    # Run every 10 minutes
+    - cron: '*/10 * * * *'
   workflow_dispatch:
     # Allow manual triggering via the GitHub Actions UI
     {}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Daily Unbiased News is a simple, static news aggregator designed to pull the
 latest headlines from multiple reputable sources and surface them in a clean,
-mobile‑friendly interface. The site is automatically refreshed every day via
-a GitHub Action, ensuring you always see up‑to‑date stories without any
+mobile‑friendly interface. The site is automatically refreshed every 10 minutes
+via a GitHub Action, ensuring you always see up‑to‑date stories without any
 manual intervention.
 
 ## Features
@@ -21,8 +21,8 @@ manual intervention.
   across all categories. Links open in a new tab.
 - **Search:** A client‑side search bar lets you filter articles by
   keyword across titles and descriptions.
-- **Daily refresh:** A GitHub Action defined in `.github/workflows/update.yml`
-  runs the `fetch_news.py` script every 24 hours. This script fetches
+- **Frequent refresh:** A GitHub Action defined in `.github/workflows/update.yml`
+  runs the `fetch_news.py` script every 10 minutes. This script fetches
   the RSS feeds, deduplicates and sorts the results, then writes them to
   `data/news.json`. If the data changes, the action commits and pushes the
   updated JSON back to your repository.
@@ -56,8 +56,8 @@ manual intervention.
 
 4. **Configure and deploy.** Push your repository to GitHub and enable
    GitHub Pages or link it to a static hosting service like Netlify or
-   Vercel. Ensure that GitHub Actions are enabled so the daily refresh can
-   commit new data. You may wish to set the deployment branch to
+   Vercel. Ensure that GitHub Actions are enabled so the scheduled refresh can
+   commit new data every 10 minutes. You may wish to set the deployment branch to
    `main` or `gh-pages` depending on your chosen hosting platform.
 
 5. **Customize.** Edit `feeds.json` to add, remove or modify feed URLs.

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -7,8 +7,8 @@ headline. The resulting structure is written to ``data/news.json``.
 
 The script is intentionally kept lightweight and uses only Python's
 standard library to avoid external dependencies. It should be run as part
-of a scheduled job (e.g. GitHub Action) to refresh the site contents
-daily. If any feeds fail to load or parse, the script will skip them
+of a scheduled job (e.g. GitHub Action) to refresh the site contents every
+10 minutes. If any feeds fail to load or parse, the script will skip them
 gracefully and continue processing the remaining feeds.
 """
 


### PR DESCRIPTION
## Summary
- run update workflow every 10 minutes instead of daily
- document 10-minute refresh in README
- note frequent schedule in fetch script docstring

## Testing
- `python -m py_compile fetch_news.py`
- `python fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab57b39ccc832d96d2636bd3a38d7f