### PR TITLE
feat: refresh news in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ manual intervention.
   the RSS feeds, deduplicates and sorts the results, then writes them to
   `data/news.json`. If the data changes, the action commits and pushes the
   updated JSON back to your repository.
+- **In-browser updates:** The front-end script automatically re-fetches
+  `data/news.json` every 10 minutes so the page shows the latest headlines
+  without requiring a manual refresh.
 - **Easy deployment:** Because the site is entirely static, it can be
   deployed to GitHub Pages, Netlify, Vercel or any other static hosting
   platform. Simply point the host to the `news_site` directory and ensure

--- a/script.js
+++ b/script.js
@@ -16,19 +16,34 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const parseDate = str => new Date(str.endsWith('Z') ? str : `${str}Z`);
 
-  // Fetch the news JSON
-  fetch('data/news.json')
-    .then(res => res.json())
-    .then(data => {
-      const categories = Object.keys(data.news);
-      buildNav(categories);
-      buildSections(data.news);
-      buildTicker(data.news);
-      attachSearch(data.news);
-    })
-    .catch(err => {
-      console.error('Failed to load news data:', err);
-    });
+  /**
+   * Fetch the latest news JSON and rebuild the page.
+   * This is invoked on initial load and every 10 minutes thereafter to
+   * ensure the content stays fresh without requiring a full page refresh.
+   */
+  function fetchAndRender() {
+    fetch('data/news.json')
+      .then(res => res.json())
+      .then(data => {
+        // Clear existing content before rebuilding
+        navContainer.innerHTML = '';
+        contentContainer.innerHTML = '';
+        tickerContent.innerHTML = '';
+
+        const categories = Object.keys(data.news);
+        buildNav(categories);
+        buildSections(data.news);
+        buildTicker(data.news);
+        attachSearch(data.news);
+      })
+      .catch(err => {
+        console.error('Failed to load news data:', err);
+      });
+  }
+
+  // Initial fetch and subsequent refresh every 10 minutes
+  fetchAndRender();
+  setInterval(fetchAndRender, 10 * 60 * 1000);
 
   /**
    * Build the category navigation buttons.
@@ -160,7 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
         originalSections[cat] = section.innerHTML;
       }
     });
-    searchInput.addEventListener('input', () => {
+    searchInput.oninput = () => {
       const query = searchInput.value.trim().toLowerCase();
       if (!query) {
         // Restore original content
@@ -199,6 +214,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         section.appendChild(list);
       });
-    });
+    };
   }
 });


### PR DESCRIPTION
## Summary
- periodically re-fetch news data on the client every 10 minutes
- document automatic in-browser refresh in README

## Testing
- `node --check script.js`
- `python -m py_compile fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab632b13d0832d8bde976e0688b225