### PR TITLE
Add theme toggle with light mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <header class="header">
       <h1 class="site-title">Daily Unbiased News</h1>
       <p class="tagline">Daily unbiased news, refreshed automatically.</p>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle light theme">Light Theme</button>
     </header>
     <div class="searchbar">
       <input type="search" id="searchInput" placeholder="Search news..." aria-label="Search news">

--- a/script.js
+++ b/script.js
@@ -6,13 +6,36 @@
  * description.
  */
 
-document.addEventListener('DOMContentLoaded', () => {
-  const searchInput = document.getElementById('searchInput');
-  const navContainer = document.getElementById('categoryNav');
-  const contentContainer = document.getElementById('content');
-  const tickerContent = document.getElementById('tickerContent');
-  const yearSpan = document.getElementById('year');
-  yearSpan.textContent = new Date().getFullYear();
+  document.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('searchInput');
+    const navContainer = document.getElementById('categoryNav');
+    const contentContainer = document.getElementById('content');
+    const tickerContent = document.getElementById('tickerContent');
+    const yearSpan = document.getElementById('year');
+    const themeToggle = document.getElementById('themeToggle');
+    yearSpan.textContent = new Date().getFullYear();
+
+    // Set saved theme on load
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light') {
+      document.documentElement.dataset.theme = 'light';
+      if (themeToggle) themeToggle.textContent = 'Dark Theme';
+    }
+
+    if (themeToggle) {
+      themeToggle.addEventListener('click', () => {
+        const isLight = document.documentElement.dataset.theme === 'light';
+        if (isLight) {
+          delete document.documentElement.dataset.theme;
+          localStorage.removeItem('theme');
+          themeToggle.textContent = 'Light Theme';
+        } else {
+          document.documentElement.dataset.theme = 'light';
+          localStorage.setItem('theme', 'light');
+          themeToggle.textContent = 'Dark Theme';
+        }
+      });
+    }
 
   const parseDate = str => new Date(str.endsWith('Z') ? str : `${str}Z`);
 

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,19 @@ body {
   font-size: 14px;
 }
 
+.theme-toggle {
+  margin-left: auto;
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+.theme-toggle:hover {
+  background: var(--panel-hover);
+}
+
 /* ====== Search ====== */
 .searchbar {
   margin: 18px 0 8px;


### PR DESCRIPTION
## Summary
- add theme toggle button to header
- persist light theme preference in localStorage and apply on load
- style toggle control for light/dark switch

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab65a0a784832d9780fc5e83b62a11