### PR TITLE
Remove broken dark/light theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <header class="header">
       <h1 class="site-title">Daily Unbiased News</h1>
       <p class="tagline">Daily unbiased news, refreshed automatically.</p>
-      <button id="themeToggle" class="theme-toggle" aria-label="Toggle light theme">Light Theme</button>
     </header>
     <div class="searchbar">
       <input type="search" id="searchInput" placeholder="Search news..." aria-label="Search news">

--- a/script.js
+++ b/script.js
@@ -12,30 +12,7 @@
     const contentContainer = document.getElementById('content');
     const tickerContent = document.getElementById('tickerContent');
     const yearSpan = document.getElementById('year');
-    const themeToggle = document.getElementById('themeToggle');
     yearSpan.textContent = new Date().getFullYear();
-
-    // Set saved theme on load
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'light') {
-      document.documentElement.dataset.theme = 'light';
-      if (themeToggle) themeToggle.textContent = 'Dark Theme';
-    }
-
-    if (themeToggle) {
-      themeToggle.addEventListener('click', () => {
-        const isLight = document.documentElement.dataset.theme === 'light';
-        if (isLight) {
-          delete document.documentElement.dataset.theme;
-          localStorage.removeItem('theme');
-          themeToggle.textContent = 'Light Theme';
-        } else {
-          document.documentElement.dataset.theme = 'light';
-          localStorage.setItem('theme', 'light');
-          themeToggle.textContent = 'Dark Theme';
-        }
-      });
-    }
 
   const parseDate = str => new Date(str.endsWith('Z') ? str : `${str}Z`);
 

--- a/styles.css
+++ b/styles.css
@@ -60,20 +60,6 @@ body {
   color: var(--muted);
   font-size: 14px;
 }
-
-.theme-toggle {
-  margin-left: auto;
-  padding: 6px 12px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel);
-  color: var(--text);
-  cursor: pointer;
-}
-.theme-toggle:hover {
-  background: var(--panel-hover);
-}
-
 /* ====== Search ====== */
 .searchbar {
   margin: 18px 0 8px;
@@ -240,17 +226,3 @@ body {
   border-radius: 8px;
 }
 
-/* ====== Optional Light Theme ======
-   Add data-theme="light" to <html> to switch.
-*/
-html[data-theme="light"] {
-  --bg: #f8fafc;
-  --panel: #ffffff;
-  --panel-hover: #f6f8fb;
-  --text: #0b1220;
-  --muted: #566073;
-  --line: #e5e9f2;
-  --accent: #2468f2;
-  --accent-weak: #1545a7;
-  --shadow: 0 8px 24px rgba(16,24,40,.08);
-}


### PR DESCRIPTION
## Summary
- strip out dark/light toggle button from layout
- remove theme switching logic and storage from client script
- drop unused styles related to theme toggle and optional light theme

## Testing
- `node --check script.js`
- `python -m py_compile fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a9cf5e8832d812baaccb1cf7658