### PR TITLE
Add bias ratings and indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ manual intervention.
   across all categories. Links open in a new tab.
 - **Search:** A client‑side search bar lets you filter articles by
   keyword across titles and descriptions.
+- **Bias indicator:** Each article carries a simple bias score based on the
+  source domain, displayed as a small color-coded marker.
 - **Frequent refresh:** A GitHub Action defined in `.github/workflows/update.yml`
   runs the `fetch_news.py` script every 10 minutes. This script fetches
   the RSS feeds, deduplicates and sorts the results, then writes them to
@@ -70,6 +72,13 @@ manual intervention.
    Each key in the JSON corresponds to a category on the site. When adding
    new feeds, ensure they provide RSS or Atom content. The `fetch_news.py`
    script will automatically pick up the changes on the next run.
+
+## Bias Scale
+
+Sources are mapped to a bias score to provide quick context for readers. The
+score ranges from **-1** (left) to **0** (center/unknown) to **+1** (right). The
+mapping is defined in `fetch_news.py`'s `BIAS_RATINGS` dictionary and can be
+adjusted as needed.
 
 ## Notes
 

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -24,6 +24,17 @@ import concurrent.futures
 from urllib.parse import urlparse
 
 
+# Simple bias mapping by news domain. Values range from -1 (left) to +1 (right)
+# with 0 representing a centrist or unknown leaning.
+BIAS_RATINGS = {
+    'reuters.com': 0,
+    'bbc.co.uk': -1,
+    'apnews.com': 0,
+    'aljazeera.com': -1,
+    'npr.org': -1,
+    'news.google.com': 0,
+}
+
 def parse_pub_date(value: str) -> datetime.datetime:
     """Parse an RSS/Atom pubDate into a timezone‑aware datetime.
 
@@ -104,13 +115,15 @@ def extract_items(xml_data: bytes) -> list:
         pub_date = parse_pub_date(pub)
         netloc = urlparse(link).netloc
         source = netloc.replace('www.', '') if netloc else ''
+        bias = BIAS_RATINGS.get(source, 0)
         items.append({
             'title': html.unescape(title.strip()),
             'link': link.strip(),
             'description': html.unescape(description_text.strip()),
             'pubDate': pub_date.isoformat() + 'Z',
             'source': source,
-            'image': image_url
+            'image': image_url,
+            'bias': bias
         })
     return items
 

--- a/script.js
+++ b/script.js
@@ -134,9 +134,18 @@
     const meta = document.createElement('div');
     meta.className = 'article-meta';
     const date = parseDate(article.pubDate);
-    meta.textContent = `${article.source || ''} • ${date.toLocaleString(undefined, {
+    const biasValue = typeof article.bias === 'number' ? article.bias : 0;
+    const biasMeter = document.createElement('span');
+    biasMeter.className = 'bias-meter';
+    biasMeter.title = `Bias: ${biasValue} (−1 left, 0 center, +1 right)`;
+    if (biasValue < 0) biasMeter.classList.add('bias-left');
+    else if (biasValue > 0) biasMeter.classList.add('bias-right');
+    meta.appendChild(biasMeter);
+    const metaText = document.createElement('span');
+    metaText.textContent = `${article.source || ''} • ${date.toLocaleString(undefined, {
       year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
     })}`;
+    meta.appendChild(metaText);
 
     const titleEl = document.createElement('h3');
     titleEl.className = 'article-title';

--- a/styles.css
+++ b/styles.css
@@ -166,6 +166,17 @@ body {
   margin-bottom: 6px;
 }
 
+.bias-meter {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 6px;
+  border-radius: 2px;
+  background: var(--muted);
+}
+.bias-left { background: #2563eb; }
+.bias-right { background: #dc2626; }
+
 .article-title {
   font-size: var(--fs-3);
   font-weight: 700;


### PR DESCRIPTION
## Summary
- assign left/center/right bias scores to feed sources in `fetch_news.py`
- show a color-coded bias meter for each article in `script.js` and style it
- document bias scale for contributors

## Testing
- `python fetch_news.py`
- `python -m py_compile fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a6572a0832d85d7909798ffa514