### PR TITLE
Enable local article comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ manual intervention.
   deployed to GitHub Pages, Netlify, Vercel or any other static hosting
   platform. Simply point the host to the `news_site` directory and ensure
   that the GitHub Action has permission to push updates.
+- **Local comments:** Any comments you post are stored only in your
+  browser via `localStorage` and are never sent to a server.
 
 ## Getting Started
 

--- a/script.js
+++ b/script.js
@@ -166,6 +166,42 @@
       wrapper.appendChild(img);
     }
 
+    // ===== Comment UI =====
+    const form = document.createElement('div');
+    form.className = 'comment-form';
+    const textarea = document.createElement('textarea');
+    textarea.placeholder = 'Add a comment';
+    textarea.rows = 2;
+    const postBtn = document.createElement('button');
+    postBtn.textContent = 'Post';
+    form.appendChild(textarea);
+    form.appendChild(postBtn);
+
+    const list = document.createElement('ul');
+    list.className = 'comment-list';
+
+    const storageKey = `comments_${article.link}`;
+    const comments = JSON.parse(localStorage.getItem(storageKey) || '[]');
+    comments.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+
+    postBtn.addEventListener('click', () => {
+      const text = textarea.value.trim();
+      if (!text) return;
+      comments.push(text);
+      localStorage.setItem(storageKey, JSON.stringify(comments));
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+      textarea.value = '';
+    });
+
+    wrapper.appendChild(form);
+    wrapper.appendChild(list);
+
     return wrapper;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -187,6 +187,49 @@ body {
   overflow: hidden;
 }
 
+/* ====== Comments ====== */
+.comment-form {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.comment-form textarea {
+  width: 100%;
+  min-height: 60px;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--text);
+  resize: vertical;
+}
+.comment-form button {
+  align-self: flex-end;
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--accent);
+  color: #0b1220;
+  cursor: pointer;
+}
+.comment-form button:hover {
+  background: var(--accent-weak);
+  border-color: var(--accent-weak);
+}
+.comment-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+}
+.comment-list li {
+  background: var(--panel-hover);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 8px;
+  margin-top: 6px;
+}
+
 /* ====== Utilities ====== */
 .small { font-size: 13px; color: var(--muted); }
 .kicker { color: var(--accent); font-weight: 600; margin-right: 8px; }


### PR DESCRIPTION
## Summary
- add textarea and Post button to each article and persist comments by URL in localStorage
- style the new comment form and list
- document that comments stay only in the browser

## Testing
- `node --check script.js`
- `python -m py_compile fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a5b4984832d9fafb3aa807c6184