### PR TITLE
Refocus site on official critical events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Daily Unbiased News
+# Critical Event Monitor
 
-Daily Unbiased News is a simple, static news aggregator designed to pull the
-latest headlines from multiple reputable sources and surface them in a clean,
-mobile‑friendly interface. The site is automatically refreshed every 10 minutes
-via a GitHub Action, ensuring you always see up‑to‑date stories without any
-manual intervention.
+Critical Event Monitor provides a trustworthy stream of officially confirmed
+incidents without commentary or speculation. Only events with clear impact are
+recorded, focusing on life safety, major events and infrastructure failures.
+The site refreshes automatically every 10 minutes via a GitHub Action so the
+feed always reflects the latest reports.
 
 ## Features
 
-- **Multiple sources:** The aggregator pulls RSS feeds from a selection of
-  sources such as Reuters, BBC, Al Jazeera, NPR and AP (via Google News).
-  The feed URLs are defined in `feeds.json` and can easily be extended or
-  modified.
-- **Category sections:** News items are grouped into major categories
-  (World, Politics, Tech, Science, Business, Culture). Each section
-  displays up to 50 of the most recent unique headlines across all sources.
+- **Official sources:** The aggregator pulls RSS and Atom feeds from verified
+  outlets such as the USGS and National Weather Service, plus targeted Google
+  News queries scoped to reputable publishers. Feed URLs are defined in
+  `feeds.json` and can easily be extended or modified.
+- **Focused categories:** Reports are grouped into three sections—Life Safety,
+  Events and Infrastructure—each showing up to 50 of the most recent unique
+  entries.
 - **Duplicate filtering:** Articles are deduplicated by title across all
   categories to avoid repeating the same story from multiple outlets.
 - **Live ticker:** A horizontal ticker bar shows the latest headlines from
@@ -34,20 +34,18 @@ manual intervention.
 - **In-browser updates:** The front-end script automatically re-fetches
   `data/news.json` every 10 minutes so the page shows the latest headlines
   without requiring a manual refresh.
-- **Easy deployment:** Because the site is entirely static, it can be
+  - **Easy deployment:** Because the site is entirely static, it can be
   deployed to GitHub Pages, Netlify, Vercel or any other static hosting
-  platform. Simply point the host to the `news_site` directory and ensure
+  platform. Simply point the host to this repository's root and ensure
   that the GitHub Action has permission to push updates.
-- **Local comments:** Any comments you post are stored only in your
-  browser via `localStorage` and are never sent to a server.
 
 ## Getting Started
 
-1. **Clone this repository** and navigate into the `news_site` directory.
+1. **Clone this repository** and navigate into the project directory.
 
    ```sh
    git clone https://github.com/yourusername/daily-unbiased-news.git
-   cd daily-unbiased-news/news_site
+   cd daily-unbiased-news
    ```
 
 2. **Install Python dependencies** (no external packages required; the

--- a/data/news.json
+++ b/data/news.json
@@ -1,25 +1,7 @@
 {
-  "lastUpdate": "2025-08-24T20:55:47.422622Z",
+  "lastUpdate": "2025-08-24T21:15:09.754660Z",
   "news": {
-    "World": [
-      {
-        "title": "Canada’s Carney meets Zelenskyy, backs security guarantees for Ukraine",
-        "link": "https://www.aljazeera.com/news/2025/8/24/canadas-carney-meets-zelenskyy-backs-security-guarantees-for-ukraine?traffic_source=rss",
-        "description": "Canadian PM floats the possibility of 'presence of troops' from allied countries to protect Ukraine against Russia.",
-        "pubDate": "2025-08-24T20:44:45Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Israel hits Yemen's Houthis after reports group used cluster bomb",
-        "link": "https://www.bbc.com/news/articles/c0kzy7r8pl1o?at_medium=RSS&at_campaign=rss",
-        "description": "The strikes come after Israel said the Houthis used cluster munitions in a missile fired at Israel.",
-        "pubDate": "2025-08-24T20:07:58Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/abb2/live/a75af680-8118-11f0-a047-cdd47dc7115a.png",
-        "bias": 0
-      },
+    "Life Safety": [
       {
         "title": "Fire at Louisiana auto plant is 90% contained while evacuation order remains - AP News",
         "link": "https://news.google.com/rss/articles/CBMiogFBVV95cUxPanMzSDV5NUZvdThBWEFuaUFRcFMwTndCZWQySlc2Y3lLcUFaSnhzVGo4M3ZuSVJRMGxZdnZzUUFvSjFTMUcyQjVreHJRYlcwVi13MDFtVndxWXRhRFRlSExJdTUtM2tibXJmWmtYNGpfd0NabjZMN2ZMODNqbGxKdHotY3ZDWG5qM2lGbWJPYWtOdnM0cmVRYVUyYWlrZVlzMGc?oc=5",
@@ -30,39 +12,12 @@
         "bias": 0
       },
       {
-        "title": "Trump has no basis to deploy troops to Chicago: Top Democratic US lawmaker",
-        "link": "https://www.aljazeera.com/news/2025/8/24/trump-has-no-basis-to-deploy-troops-to-chicago-top-democratic-us-lawmaker?traffic_source=rss",
-        "description": "Illinois Governor JB Pritzker also accuses Republican US president of pushing to 'manufacture a crisis' to abuse power.",
-        "pubDate": "2025-08-24T19:34:19Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
         "title": "‘Sopranos’ star Jerry Adler, Broadway backstage vet turned late-in-life actor, dies at 96 - AP News",
         "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxNREl1TzZJTXpUWGl0OXRqMkxjYnBUcldXUFJSeHhrMW9pOWZQbmRLX1BaemhGX1h4U1B4RTZ6cFNrNk9xVllIUGQ3c2kxUDJtcmdOcm85N3l2V2F6RUpvMnpnNFlrWmRwUDI5UFJnRzRRY0VDSTFoaHdqaHVGMjFkZkdWVFZCY1lGbnRoZHU2ekVxX2ZYWUE?oc=5",
         "description": "",
         "pubDate": "2025-08-24T19:11:00Z",
         "source": "news.google.com",
         "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Tens of thousands march across world in support of Palestinians in Gaza",
-        "link": "https://www.aljazeera.com/news/2025/8/24/tens-of-thousands-march-across-world-in-support-of-palestinians-in-gaza?traffic_source=rss",
-        "description": "Rallies take place across Australia's major towns and cities as well as in other countries including Malaysia and Kenya.",
-        "pubDate": "2025-08-24T18:57:28Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Zelensky vows to continue fighting as Ukraine marks independence day",
-        "link": "https://www.bbc.com/news/articles/czxy2v9dzgxo?at_medium=RSS&at_campaign=rss",
-        "description": "Russia said power and energy facilities had been targeted by Ukraine, which accused Russia of \"spreading manipulations\".",
-        "pubDate": "2025-08-24T18:42:54Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/5492/live/2289f7b0-80f7-11f0-93a2-5b14be878525.jpg",
         "bias": 0
       },
       {
@@ -75,42 +30,6 @@
         "bias": 0
       },
       {
-        "title": "UK's Chagos Islands deal 'significant victory', says Pope",
-        "link": "https://www.bbc.com/news/articles/cx2p1k1r2glo?at_medium=RSS&at_campaign=rss",
-        "description": "Pope Leo XIV said he hoped Mauritian authorities would ensure the refugees are able to return home.",
-        "pubDate": "2025-08-24T17:56:10Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/5d3f/live/291e88f0-8063-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Amid Gaza famine, Palestinian girl struggles to survive",
-        "link": "https://www.aljazeera.com/news/2025/8/24/amid-gaza-famine-palestinian-girl-struggles-to-survive?traffic_source=rss",
-        "description": "UN official says Palestinians in Gaza are experiencing 'hell in all shapes' as Israel steps up its Gaza City assault.",
-        "pubDate": "2025-08-24T17:44:41Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Ghislaine Maxwell’s testimony says a lot about our dystopia",
-        "link": "https://www.aljazeera.com/opinions/2025/8/24/ghislaine-maxwells-testimony-says-a-lot-about-our-dystopia?traffic_source=rss",
-        "description": "That the US president needs a character certificate from a convicted criminal is quite befitting.",
-        "pubDate": "2025-08-24T17:24:07Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "LIVE: Real Oviedo vs Real Madrid – La Liga",
-        "link": "https://www.aljazeera.com/sports/liveblog/2025/8/24/live-real-oviedo-vs-real-madrid-la-liga?traffic_source=rss",
-        "description": "Follow the build-up, analyses and live text commentary of the game as Oviedo host Real Madrid in Spain's La Liga.",
-        "pubDate": "2025-08-24T16:40:00Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
         "title": "Sudan’s paramilitary forces kill 13 people in Darfur, mostly women and children, group says - AP News",
         "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxQcm9WYkhRZXZFNzkxZDFSTFJ5Z0JVSTBmaEVUaWZuc0RzLXU0cVh2dmRBOTI3aDNueS01dEwxMFVhcnZzMjZoUkpyWWpiblJTZlVUQ0VtS2ZpN0R3ZE9OSHZ6U3AwWEtlQmtfanpVSEJMVGVyekxWU3FMX01fZnNhaGx1Z3RuUWFidzlmNDgzSjBJT3M?oc=5",
         "description": "",
@@ -118,60 +37,6 @@
         "source": "news.google.com",
         "image": "",
         "bias": 0
-      },
-      {
-        "title": "Why protesters in the UK are being arrested under ‘terror’ laws",
-        "link": "https://www.aljazeera.com/video/the-stream/2025/8/24/why-protesters-in-the-uk-are-being-arrested-under-terror-laws?traffic_source=rss",
-        "description": "Why some protests in the UK are being criminalised, and what that means for free speech.",
-        "pubDate": "2025-08-24T15:46:30Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Moscow says Russia and Ukraine exchange 146 prisoners each",
-        "link": "https://www.aljazeera.com/news/2025/8/24/moscow-says-russia-and-ukraine-exchange-146-prisoners-each?traffic_source=rss",
-        "description": "The exchange comes amid diplomatic efforts to solve the conflict and a Ukrainian drone attack on Russia overnight.",
-        "pubDate": "2025-08-24T14:57:09Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "More than 30 jihadists killed in air strikes, Nigerian military says",
-        "link": "https://www.bbc.com/news/articles/cq58123z814o?at_medium=RSS&at_campaign=rss",
-        "description": "Concern is mounting about \"war-time levels of slaughter\" in Nigeria, including a resurgence of jihadist activity.",
-        "pubDate": "2025-08-24T14:38:15Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/e245/live/92ae2890-80f7-11f0-93a2-5b14be878525.jpg",
-        "bias": 0
-      },
-      {
-        "title": "More than 500,000 ordered to evacuate as typhoon heads for Vietnam",
-        "link": "https://www.bbc.com/news/articles/cx2pw5ypwqeo?at_medium=RSS&at_campaign=rss",
-        "description": "Typhoon Kajiki is brushing past Hainan in China before heading for Vietnam, forecasters say.",
-        "pubDate": "2025-08-24T14:34:38Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/4316/live/348d6cd0-80f2-11f0-93a2-5b14be878525.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Zelenskyy marks Ukraine Independence Day alongside Canada’s PM in Kyiv",
-        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/zelenskyy-marks-ukraine-independence-day-alongside-canadas-pm-in-kyiv?traffic_source=rss",
-        "description": "Ukrainian President Zelenskyy delivered a defiant address against Russia during Ukraine’s Independence Day.",
-        "pubDate": "2025-08-24T14:32:27Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Iran will stand up to US demands to be ‘obedient’, says Khamenei",
-        "link": "https://www.aljazeera.com/news/2025/8/24/iran-will-not-be-obedient-to-us-nuclear-demands-says-khamenei?traffic_source=rss",
-        "description": "The remarks by Supreme Leader Ayatollah Ali Khamenei comes as Tehran agrees to hold nuclear talks with European powers.",
-        "pubDate": "2025-08-24T14:28:06Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
       },
       {
         "title": "Maria Sharapova and Bryan Brothers enter tennis hall, with surprise appearance by Serena Williams - AP News",
@@ -183,192 +48,12 @@
         "bias": 0
       },
       {
-        "title": "Three sisters drown in migrant boat in Mediterranean, rescuers say",
-        "link": "https://www.bbc.com/news/articles/cp89rqgjq1no?at_medium=RSS&at_campaign=rss",
-        "description": "There was \"sheer horror\" when survivors realised that the girls aged nine, 11 and 17 had died, a rescuer says.",
-        "pubDate": "2025-08-24T14:26:21Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/20de/live/8804ba50-80e6-11f0-b8f2-7d2c83388047.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Marc Marquez wins Hungarian MotoGP for seventh straight victory",
-        "link": "https://www.aljazeera.com/sports/2025/8/24/marc-marquez-wins-hungarian-motogp-for-seventh-straight-victory?traffic_source=rss",
-        "description": "The six-time MotoGP world champion is undefeated since June and is rapidly closing in on another riders title.",
-        "pubDate": "2025-08-24T14:11:54Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Palestinians fear advancing Israeli assault on Gaza City",
-        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/palestinians-fear-advancing-israeli-assault-on-gaza-city?traffic_source=rss",
-        "description": "As Israel advances further in towards Gaza City, Palestinians like Mohammed Zaher fear another forced expulsion.",
-        "pubDate": "2025-08-24T14:08:26Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Pro-Palestine protesters rally in cities across Australia",
-        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/pro-palestine-protesters-rally-in-cities-across-australia?traffic_source=rss",
-        "description": "Tens of thousands of protesters have demonstrated in cities across Australia in solidarity with Palestinians in Gaza, de",
-        "pubDate": "2025-08-24T13:41:01Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Israeli bombardment kills four in Yemen’s Sanaa after Houthi attacks",
-        "link": "https://www.aljazeera.com/news/2025/8/24/israeli-military-targets-yemens-sanaa-after-houthi-attacks?traffic_source=rss",
-        "description": "Houthi official says Israeli attacks will not stop group from continuing support for Gaza, 'no matter the sacrifices'.",
-        "pubDate": "2025-08-24T13:39:35Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Israel’s targeting of journalists in Gaza continues",
-        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/israels-targeting-of-journalists-in-gaza-continues?traffic_source=rss",
-        "description": "A journalist in Gaza reported on the killing of his relatives, live on TV, just hours after losing a colleague.",
-        "pubDate": "2025-08-24T13:32:18Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "How burgers helped me better understand my Vietnamese immigrant mother",
-        "link": "https://www.aljazeera.com/features/2025/8/24/how-burgers-helped-me-better-understand-my-vietnamese-immigrant-mother?traffic_source=rss",
-        "description": "Once, eating cheeseburgers allowed my mother to feel American. Now, it shows that she is free to eat what she wants.",
-        "pubDate": "2025-08-24T13:28:54Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Israeli protesters confront far-right Security Minister Itamar Ben-Gvir",
-        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/israeli-protesters-confront-far-right-security-minister-itamar-ben-gvir?traffic_source=rss",
-        "description": "A group of protesters confronted Israel's National Security Minister Ben-Gvir, accusing him of pursuing war.",
-        "pubDate": "2025-08-24T13:06:00Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Russia accuses Ukraine of attacking nuclear plant, causing a fire",
-        "link": "https://www.aljazeera.com/news/2025/8/24/russia-accuses-ukraine-of-attacking-nuclear-plant-causing-a-fire?traffic_source=rss",
-        "description": "No increase in radiation levels detected after drone strikes, Russian officials say on Ukraine's Independence Day.",
-        "pubDate": "2025-08-24T12:48:27Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Israel pounds Gaza City in preparation for planned offensive",
-        "link": "https://www.bbc.com/news/articles/cvg478y8l09o?at_medium=RSS&at_campaign=rss",
-        "description": "Sixty-four people were killed in Israeli attacks across Gaza in the past 24 hours, the territory's Hamas-run health ministry said.",
-        "pubDate": "2025-08-24T12:18:44Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2dc8/live/3ea13c80-80dc-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "After the Taliban cut Afghan drug production, new suppliers emerge",
-        "link": "https://www.aljazeera.com/video/project-force-2/2025/8/24/after-the-taliban-cut-afghan-drug-production-new-suppliers-emerge?traffic_source=rss",
-        "description": "In this episode, @alexgatopoulos examines developments in a trade that helps fuel wars around the globe",
-        "pubDate": "2025-08-24T12:08:40Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Hadeel & Abdelrahman in Gaza",
-        "link": "https://www.aljazeera.com/video/on-the-ground/2025/8/24/hadeel-abdelrahman-in-gaza?traffic_source=rss",
-        "description": "A video diary for Al Jazeera",
-        "pubDate": "2025-08-24T12:05:45Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Cutting Russia off from the web",
-        "link": "https://www.aljazeera.com/video/digital-dilemma/2025/8/24/cutting-russia-off-from-the-web?traffic_source=rss",
-        "description": "In this episode, @MissSamJohnson looks at how Russia has been whittling away its citizens online freedoms",
-        "pubDate": "2025-08-24T11:59:27Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Bangladesh holds international conference on Rohingya: Here’s what to know",
-        "link": "https://www.aljazeera.com/news/2025/8/24/bangladesh-holds-international-conference-on-rohingya-heres-what-to-know?traffic_source=rss",
-        "description": "Two-day meeting gives a glimmer of hope for the Rohingya refugees forced to flee Myanmar crackdown in 2017.",
-        "pubDate": "2025-08-24T11:58:52Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Anti-refugee protesters in the UK rally against hotels for asylum seekers",
-        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/24/anti-refugee-protesters-in-the-uk-rally-against-hotels-for-asylum-seekers?traffic_source=rss",
-        "description": "Far-right protesters and anti-racism campaigners have faced off at rallies across the UK against hotels housing asylum",
-        "pubDate": "2025-08-24T11:57:54Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Protesters rally across Australian cities to demand end to Gaza genocide",
-        "link": "https://www.aljazeera.com/gallery/2025/8/24/protesters-rally-across-australian-cities-to-demand-end-to-gaza-genocide?traffic_source=rss",
-        "description": "Australians join nationwide rallies for Palestine after statehood recognition strains ties with Israel.",
-        "pubDate": "2025-08-24T11:56:57Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "How Ukraine and Russia will view Trump's attempts to broker a peace deal",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5509676/how-ukraine-and-russia-will-view-trumps-attempts-to-broker-a-peace-deal",
-        "description": "NPR's Ayesha Rascoe speaks to Yaroslav Trofimov from the Wall Street Journal about how President Trump's attempts to end the war in Ukraine will be viewed in Moscow and Kyiv.",
-        "pubDate": "2025-08-24T11:55:01Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
         "title": "Little legs, big dreams: More than 100 teams compete in Lithuania’s international Corgi race - AP News",
         "link": "https://news.google.com/rss/articles/CBMimAFBVV95cUxQYW9QMk9xcGQ3TUxITVVxVHpiazJ2aExSZTJOT0FpRnNVVXgzMjdDTDNEcWVaNjdydzF5LVdMbnR6cHJaOGtoaXlsUllrcl9rbkUxLTh2TVZGV2U3Z0R1YnNnVHM2bF9Jc0RJSUhJaWladkZ1dVZCdkhXMFQzTFF3c1cxTU5HRnZkbjZ0VUhQMlpnRHQ4OFJCVA?oc=5",
         "description": "",
         "pubDate": "2025-08-24T11:47:00Z",
         "source": "news.google.com",
         "image": "",
-        "bias": 0
-      },
-      {
-        "title": "There is something worse than starvation in Gaza",
-        "link": "https://www.aljazeera.com/opinions/2025/8/24/there-is-something-worse-than-starvation-in-gaza?traffic_source=rss",
-        "description": "It is Israel killing hope with its ceasefire negotiations games.",
-        "pubDate": "2025-08-24T11:24:06Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Watch: Solar-powered cars start epic Australian outback race",
-        "link": "https://www.bbc.com/news/videos/ckgd7r2mrl2o?at_medium=RSS&at_campaign=rss",
-        "description": "Thirty-four teams from all over the world are competing to win the 2025 Bridgestone World Solar Challenge.",
-        "pubDate": "2025-08-24T10:39:23Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/48d1/live/e28ff540-80d5-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "My trip to North Korea's 'Benidorm' - flanked by guards and full of rules",
-        "link": "https://www.bbc.com/news/articles/c707d1ez0kno?at_medium=RSS&at_campaign=rss",
-        "description": "Anastasia, one of the first Russian visitors to North Korea's new resort, tells of \"immaculate\" beaches, meaty meals and strict rules.",
-        "pubDate": "2025-08-24T07:36:33Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/dd1b/live/03aa4310-7eac-11f0-a5e2-236e16f99597.jpg",
         "bias": 0
       },
       {
@@ -399,210 +84,136 @@
         "bias": 0
       },
       {
-        "title": "North Korean leader oversees new missile test, state media says",
-        "link": "https://www.bbc.com/news/articles/cj3lp47nxdjo?at_medium=RSS&at_campaign=rss",
-        "description": "Two new air defence missiles with \"superior combat capability\" have been fired in a test observed by Kim Jong Un.",
-        "pubDate": "2025-08-23T23:51:33Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/048c/live/11cef040-807c-11f0-9c84-8f69c101453a.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Photo highlights from the rhythmic gymnastics World Championships in Brazil - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiuwFBVV95cUxOMmZkcVZaR2E2SWNhWWhxYTB2OFRrZ1pmNFhQeVlpYnhlUVZLaksxY0lJUzVJaGJHVDdHNTNESkdWN0dTZ3dRX0l4UF9qWmVFbHo1UnNjaDBSajJNSks4SGQwWkhtcEpZOVctUF9oZFpWNjJPSkUwNkZhWnRFM0hKeWNzc1NGdzJlTHliQWc0VzdkU1lWZDZLRXg4OEY3MWVGcElybUFhRWx4U2FtQThrOVBXdGNJeDdnV2Nn?oc=5",
+        "title": "Lions QB Kyle Allen, rookie WR Isaac TeSlaa solidify roster chances in 26-7 preseason loss to Texans - AP News",
+        "link": "https://news.google.com/rss/articles/CBMihAFBVV95cUxPR2RSMGc5bzdzdmEtUXgwbVp4NTcyMTNQZVFjbkxfOGVGUjRnNHZ1dU1RYkE2RmlCREhVbmxpTXpabm9CVHpNZHZYalE3T3lPQkZyaXdLYk5UcjZ5V21lOWhqZ0xYNDdKZWlrU3BxUEFrSXlnRU1TMXBuQVE3MFZzUHdJekE?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T23:31:00Z",
+        "pubDate": "2025-08-23T20:58:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "For orca left in limbo, zoo resorts to sexual stimulation to stop inbreeding",
-        "link": "https://www.bbc.com/news/articles/cedvp89jy4do?at_medium=RSS&at_campaign=rss",
-        "description": "Wikie, 24, and her 11-year-old son Keijo still don't have a new home despite months of wrangling.",
-        "pubDate": "2025-08-23T23:09:04Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/7377/live/5ea77ca0-f686-11ef-9e61-71ee71f26eb1.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Nevada to face Taiwan in the Little League World Series final - AP News",
-        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxNOXlYSFcxQ2FzVFVkOUgyZ2ZvN1oyUDdvRjJLSnZ5Q09tWGZPTWZGb0RfZ1lBMEx3N0pyeFVkWHh6MmRycEpOdUN5dnVma2lLRUwtME94MWFsNF80Sk9jTzdaVDZkRE9UZlp3YjBhdUVDV2FwSzNOdENDeDlTVEtoRGQ2V05relJod0tGakVZZE1uanlmVHh4N1Jhdk8?oc=5",
+        "title": "Truck driver accused by the Trump administration of being in the US illegally is denied bond - AP News",
+        "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxONDFzbW42UDJ3eEQxM09lcngyZ1F1bFdXM2JES3hpTnFQeHRsUU1JSTVRdS1mNHc3NjQzTWR2cldtSkJVMEp2eEd5R3N3blhsNHFCTFk0SHhYb3hWTGIyTDFGejAxUmJiTHgzazBvN0h2REpXRVhYYjZIVjN3RkgxeGFZYjEycHhnTXBvWjE5OFhJVFZuUEJ0M0hRUkl4UkxNSHJoTlE3NDJmeFlmWnJZSjZR?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T22:35:00Z",
+        "pubDate": "2025-08-23T19:55:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Boxed in by shifting tariff rules, European shippers pause some U.S.-bound parcels",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5513936/dhl-parcel-tariffs",
-        "description": "New customs regulations take effect August 29, and many European postal agencies and companies say until new systems are set up they can't ship some goods. Gifts worth less than $100 are not affected.",
-        "pubDate": "2025-08-23T22:21:20Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "High stakes diplomacy and canceled Halibut Olympia, insights from the Alaska Summit",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5508462/high-stakes-diplomacy-and-canceled-halibut-olympia-insights-from-the-alaska-summit",
-        "description": "NPR's Mary Louise Kelly, who has covered her share of high stakes diplomatic meetings between some of the world's most powerful people, spoke with Scott Detrow about what was different during the recent Trump-Putin Alaska Summit.",
-        "pubDate": "2025-08-23T21:20:14Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      }
-    ],
-    "Politics": [
-      {
-        "title": "Government plans to overhaul asylum appeals system",
-        "link": "https://www.bbc.com/news/articles/cg4xp4ywk47o?at_medium=RSS&at_campaign=rss",
-        "description": "The government would establish a new and independent body, with the aim of hearing cases more quickly.",
-        "pubDate": "2025-08-24T18:19:40Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8501/live/e385e010-80ab-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Pub and travel bans proposed under sentencing rule changes",
-        "link": "https://www.bbc.com/news/articles/c5ypej14j2xo?at_medium=RSS&at_campaign=rss",
-        "description": "Ministers say the reforms are aimed at reducing reoffending and easing pressures on crowded prisons.",
-        "pubDate": "2025-08-24T16:17:49Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/36c5/live/38b8b3b0-80b5-11f0-a2f6-4feea1120fa7.jpg",
-        "bias": 0
-      },
-      {
-        "title": "At least 1 dead in Moscow shopping center explosion, 3 injured - AP News",
-        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxQTkFSV1FmWi1hZkZ0X2l3V3R1MjV5LU1VWXJ1ZXpYRndhUTVLRUdRQkpRTl93RjRxY0F4S0ZTelF4NmFKVDZGOTJNdTFyaWd1ZEdnWlhkNGdzZ1Yxdy11eEhVRF83bURNaUwyQUFlbjlhcXBsYnY5MVNWUVdyNWlJYTlzN3EzbGVVM1BndGpfaFJ0STlOWWV4NExWaFg?oc=5",
+        "title": "Gyokeres scores his first goals for Arsenal in 5-0 rout of Leeds, impressive Tottenham beats City - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxOMlAydHRiYjBnMS1IVl9vTVRyQVFYMVc1Vm5rT19KdUJQRnEtay1wbmUtRjFadFFsTXd3N3BUZ0lRSGZuV3hSdWNJdjM3MnA1Wm95RkVfemJ3dXM2dFRSeWhxZmc0d3BQaHBXYldWT090b2h6Ri1TLTFZSXRmaF9YbHp3QXVldGpWSTJKZ1lNanRFUGRaSGd6QXlOcXZZMTE3NHJzalNURTZ5c28?oc=5",
         "description": "",
-        "pubDate": "2025-08-24T12:27:00Z",
+        "pubDate": "2025-08-23T19:50:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Politics chat: FBI searches John Bolton's home, National Guard in Chicago?",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5508934/politics-chat-fbi-searches-john-boltons-home-national-guard-in-chicago",
-        "description": "We discuss the latest political news, including the FBI search of former Trump adviser John Bolton's home and whether President Trump will send National Guard troops to more cities.",
-        "pubDate": "2025-08-24T11:54:57Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Smithsonian artists and scholars respond to White House list of objectionable art",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5511241/smithsonian-white-house-art",
-        "description": "A page published by the White House entitled \"President Trump Is Right About the Smithsonian\" lists exhibits, educational sites and more that the administration seems to take issue with.",
-        "pubDate": "2025-08-24T09:07:29Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Clarkson for PM, attacks on police dogs: Do Parliament petitions make a difference?",
-        "link": "https://www.bbc.com/news/articles/cg4xqn91rwlo?at_medium=RSS&at_campaign=rss",
-        "description": "People love signing petitions to get issues they care about debated by MPs - but some can't resist having a laugh.",
-        "pubDate": "2025-08-23T23:40:38Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d717/live/7bf0f3a0-8046-11f0-9048-d5a54170a86f.png",
-        "bias": 0
-      },
-      {
-        "title": "US seeks to deport Kilmar Abrego Garcia to Uganda after he refused plea offer in his smuggling case - AP News",
-        "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxOeXREMHZ6RlM3M1k5Qk5IeFZKQ2FQZDBBcDhGZWsyVTc2ajV0Zi1aaVpLc1J1cVhHNWhiVzBCMXhvcEV2ZkFXcWtaNHhVYXZRYWJGNmlwTDhyWFBrUU1yMmxWQnNVdUw2ajI1ZHZ2NzN2S0ZnUjJJRGtrT2dqZEZXdkVSWnVaLV9RTEtJV0trSnVDTTU0a1l5SW9ibzROeFJfTU9oLUZR?oc=5",
+        "title": "The Menendez brothers were denied parole. They have to wait at least 18 months for their next chance - AP News",
+        "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxPb1JVOEZOVDNFN1pGMk1zSnppeWpuWHBsZldVUkpFRlZWU2F5ZlFVb0dNWlZLM1RMekEzTGhJS0FCbTlqSUN0UXNwRzd3SGItNWd4RERYV0hZV29tX0hSTUpfbzMwTDhCcnhVc2p4ZzVEbERJazE0SzJRdG50b1hUSTdGa3o3czBIR3BKVGE4ejcwT2ZBakxFdmhfTDRfN2twLWZqQ3RtcmZYcGpQZVZF?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T20:02:00Z",
+        "pubDate": "2025-08-23T18:06:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "It's been a busy week at the Justice Department. Here's a recap",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5511436/its-been-a-busy-week-at-the-justice-department-heres-a-recap",
-        "description": "The Department of Justice has been in the news all week, both over its handling of the Epstein investigation and its search of a home of Trump's former national security adviser.",
-        "pubDate": "2025-08-23T11:47:57Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "A former federal prosecutor reviews legal options against assertive presidential power",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5511330/a-former-federal-prosecutor-reviews-legal-options-against-assertive-presidential-power",
-        "description": "NPR's Scott Simon talks with Politico's Ankush Khardori about what legal checks remain as the Trump administration flexes presidential power.",
-        "pubDate": "2025-08-23T11:47:53Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Week in Politics: Trump and Putin; possible rate cuts; lawmakers and redistricting",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5509911/week-in-politics-trump-and-putin-possible-rate-cuts-lawmakers-and-redistricting",
-        "description": "We discuss the latest political developments, including President Trump's crackdown in Wahington, D.C., and redistricting efforts in Texas and California.",
-        "pubDate": "2025-08-23T11:47:38Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "What's the Canadian movement known as 'elbows up' and its link to tariffs?",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5507154/whats-the-canadian-movement-known-as-elbows-up-and-its-link-to-tariffs",
-        "description": "NPR's Scott Simon speaks with Donna Noade Reardon, mayor of St. John, New Brunswick, about how President Trump's tariffs have affected her province as well as Canada's relationship with the U.S.",
-        "pubDate": "2025-08-23T11:47:28Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Trump makes over the Rose Garden, Mar-a-Lago style",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5509554/rose-garden-paved",
-        "description": "Trump has swapped out the grass in the Rose Garden with stone, turning what had been a lawn into a patio that bears a striking resemblance to one at his Mar-a-Lago resort in Palm Beach, Fla.",
-        "pubDate": "2025-08-23T09:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Farage vows mass deportations to tackle small boats",
-        "link": "https://www.bbc.com/news/articles/c9vd3rx33g1o?at_medium=RSS&at_campaign=rss",
-        "description": "Plans outlined by the Reform UK leader would see the country taken out of the European Convention on Human Rights.",
-        "pubDate": "2025-08-23T08:38:04Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/309e/live/e4740a20-7fba-11f0-9481-1fe1ca574d00.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Congo’s prosecutor asks for the death penalty for former President Kabila for war crimes - AP News",
-        "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxPSHJSWF9KWlo1VmlaVVJxS05scVhpblhTNEp6cTFDU3d0ZEFBSnRwU1dEbEpxMzV1SjlEaThMcWZObXRsV1RzdENraXp4bXFoUUYtTG1hckVRYWNvajhKSnJjdmFrY1FVZ0lJbWpsT2pCcmlURW5GRXVORDhWMFE4NWZLcC1aYlRqeTNZb1VUOA?oc=5",
+        "title": "Mirra Andreeva, Vicky Mboko, João Fonseca and Learner Tien are teens to watch at the US Open - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxOem44NGlMbFQ4LVFJQUllU0hmZ090My0yeUFjMzhJS2I3UnoycjlsRXRSSlc3YjZJV0VmTzhYRzlOa1I1eWFKRDRBS2hOV2xTalhKYVh5REZXRzF3Y2k4SjdGU3lpajBzYnJmeXg2a2NJSUJ3NmNXbDR4SVZiN3BHUHF2MmhXWkJ3T2pJbm5jSVd6TFlrcEpIR3d5X2ljbDNMWjdaZmxxSFk?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T08:27:00Z",
+        "pubDate": "2025-08-23T17:06:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Photos from the Texas Legislature as Republicans push for new political maps - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxOU0YyMnZMVnNiRmlsVmtKY0JkX3UwbkFMRjVRWFlWMTZMdFhabFRrV21NSVRlbWxaWEZqZVZSVVJ6MXBNRkNnTEVOZnMxZVdMbW1UejVRVEdoN2llN09la0FiZVBhS200SjFVeWJNR2RfUlZkNFRuVk1USE1SYm14MjVNRXlKSjBsNW1YVncyM3FkbUhOVzdmeW9pMEkyRnZOMHlVX2ZNSkRBUjEzRGVUY052Zlg?oc=5",
+        "title": "Railroad companies fail to join safety program after toxic Ohio derailment - AP News",
+        "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxPRGZhdnZjdmJoTlFab0FmbFB5WXp3Y0NoNmJGTXhRbEQxd3pIb1h2MGp1SWJBUzJkTGRyT3ExeWVZbkV3MG4ydWZRU3Byd1JuQ25sbFBBb3dIa0dJdEo0WXcyeTYtdUpHSVMwOGtiUmFzNTJWaGZaRkZxS3VwQXI1eFdjaUVFeUNXdHhrNng3eXdyOGtRTm9Z?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T07:17:00Z",
+        "pubDate": "2025-08-23T16:52:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Female political prisoners in Belarus face abuse, humiliation and threats of losing parental rights - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxNZHRuZXVJY1lQZ0hYMFd0X2VqOUxlXzN3UF9oSlJqaXlMTW5pSk9Id2lOSHJWeW9Jc0ZlQUtZM2ltaDVIOHVRZkdlbGtteV9wX0JUX2RuZzRFUm1JQmpHT2RQT19IWjRQWG03cTNpbEc1ZVRoZUZSbFBQRlE0eENFTHFwUHBuNDdQUERfMzVWdkZuVnFHeTlkRFZpaVp2VlVsRmM5ZXY3RFV2WHljWUo3MTd5aHo?oc=5",
+        "title": "California bill would require restaurants to disclose food allergens on menus - AP News",
+        "link": "https://news.google.com/rss/articles/CBMivwFBVV95cUxOYV9Pb09nZzZEMERiSGNxSl82SkhyV1NLMHdEUER6eHEwT09QNjFHTXNadWkyX2VPNWphUEhpY1owVzVnb0UtV0t5N3c1YTNQd3QwUnlfZWVoOEFSTW9aSERXcmc4amUwMkVpcWxOVzl0RVZhMGxWdEd2LVdqQnZjVl80aGxmUXVEV0xXZnJHX0NVZkJKQXJqUFJHNVpFMThuWmZuNko5VWhRaTdoaHlNYXJMdWxrdlJtbW0ya1k4SQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T05:01:00Z",
+        "pubDate": "2025-08-23T15:50:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Police notified after neon green sex toy thrown onto field during Titans preseason game - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxObmdVbjN3cjZ6Qlo1NzZKcW1DWHBGOXBSWWwtQzJEa2I5TTdMWXUwMjZpRTlqUXNSbnBUWXZGdnJUMFdpY3JRU1U4aFJEZzZOd2xubk8tSXZ0eTR2RDF1dG1yYU5PVVhwRlVfZ19qZXJPUlVpSVNZMFVYRmY0QWI4OXdDc1pCa0ZrYTl5a29ia1FkRTA?oc=5",
+        "title": "Pope affirms right of people to return home after unjust exile in meeting with Chagos refugees - AP News",
+        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxPLTF3OXFvZG5YY3dfRmRXZk5odFJnREd2NzcxU2xMeVNrOUZ3aFJheDRrTE9MaXp3SGpPTm9kSGg3UEVibVEySmI2QWFNM2RpdGxiQkN5djk2dm0xRkl3LXJKaFlraU5ibTFrMVU5ckJQYkxQUkZMdTRta1lDZ2NzaDIzY0JOd0JDV1NyMWV4Z1M?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T04:02:00Z",
+        "pubDate": "2025-08-23T15:40:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Doctors in Gaza say patients’ protruding ribs and bony limbs offer evidence of malnutrition - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxPTkpSZmhENmtDTGRMSkVfdmJwTHdTeEw1WDRLY2tzZlBwYXRTVFNsTDM2TnVucDhqRTFrVGxzOF9lU2NJdzQ2YkZtUTFyd1FobU9WN0QwamVObno4YkxtY19lWlpOUnFWQXh4SVQwT0RWY1hfX2otSnJCWGZJM2k2VEozd0xaSVhfRlNUbkxsYnZ3UWpuWUN5aVgwM0JPclZuUGdsWlQ4THRucEVKWWtJNkVjQTcwb1piUEE?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T14:00:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "A quick look back at this week’s biggest stories - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiuwFBVV95cUxPbXpKWElzOHp1Mk5uZl9BTE1NOWhCSzdwYzRkUG1RLVoyZ3RiYm5PQzhtYm1UWEhIVnlFSTNrX29ibVpJYm5tOHYwRGRvMFBrc1pZWFFkVlY4Yjhjb3BUamZsRnRlUDV3b09OejRTaUdTTXdFelhueHhyTll4Z0tlR0lkT1lHWmZUUDRnNHJ1aU9VZTluTlRxQjB5Z3lVR2Q4UmhNVTYxY3hOZjlBOUhuOEZIQk5BdXpSODJJ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T13:09:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Hurricane Erin never hit land or caused major damage, but threatened turtle nests weren't so lucky - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiowFBVV95cUxQMUVzejYwR05UYkZZa2ZNVlF0bFNMMXNHVmJmeTNnVTNUM3RGNWNvbUFIalFfQkluWEF6VTNCcHBOUzFMV3ZIN2ZjT0Z4TGg3OXBPNEhxMUZFcGFWZzhZd3l0TDlLenhZSGkzTXhqdTYyWmppM2lYdWw5WFFhQ0tBWmRvSC1kSXh1UDl0akZJRjJaNjZlNXd5VHdCT05yLUxzVzdN?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T04:57:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Mahomes leads sharp Chiefs offense before Bears rally for 29-27 win in preseason finale - AP News",
+        "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxPX2VpR2k3YnpWR3pOR1BpcDkzdHEtSUVuT3I1STF5cmgxcUQwSWVab3BEeWNXZVluM0xEbUFObkZMSV95dDhibEJick5nSko0REJ6SFYyUmhUQl9xU2ctbFlaZzBnWWdCRzk0clVUdXFkbmk3QWNHZ0xtRlVTTF90azZmcnZ0MWVsei1iQk1yN05DdzA3emJUajlpek9HR2FBekRpS28wR2NQSUpXcjRlVXpn?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T04:27:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "First Erik Menendez, then Lyle denied parole by California board that says they pose safety risk - AP News",
+        "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxOckdPcFZVUm4wUzVwWmRYV2FFTURQN1VSemg4bUNnZFBoeWZadXNRdFFYb2d2bkF4NVlOVGYtd1hJQ3NEU3EtRU9mazZfYVFjQ2pxc2U1ZFBsNHlrS0REZ3F3NzJkbmhldjJ0WXJ5ZDZSMGZHaGJ0NzkydXhyNkl5SXBWYmxCR1FFN0VWa1NJZHFkRElCbzgwNkV1OHBBaEhHTGl3LQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T03:56:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Pirates rookie Bubba Chandler makes history during electric, efficient major league debut - AP News",
+        "link": "https://news.google.com/rss/articles/CBMimAFBVV95cUxPVFdXaHk5cGJsX2tPTVdLLXIzc0d4V3FvX2trMVhvalFxQXBPRWJXYkNYbTdsRkJKZ3ZWRGNIMF9pTkVmdDJsZ3VtOUQ2SWVhZkZCWFI2NXdHSVlxWkZvS05TLXBEMmZKRmRROVFVU1FSZGZFdFgzUi14aEU4bjh6TEtKcGltNjh1Uy10Skctb0oyeGZuWTg2Vw?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T03:30:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Rural Colorado mourns 6 who died from suspected gas exposure at dairy farm - AP News",
+        "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxPcHJDRDQzWkxHaHJGaEhIOWZQRnA2azIwd3REMF83ZnpxdDBFYWJtazBVQU1Ib0o4RjAxSU15cEtYbFMxY2RRSERiUUtYSEMtSlVmWTBBZmk4TUdmVGxMVnBUUmFkWnR5ay02ZFlCWXJLdk5kckJxZTBLNnpXVlh2WC1Kd2d3QlZmdGdCMk1ZdmVxeDh3bkxDTjJWQnQzZDBW?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T03:14:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
@@ -617,39 +228,84 @@
         "bias": 0
       },
       {
-        "title": "North Korea accuses South of ‘serious provocation’ over border warning shots - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxQSFlCUkhnTVBCZW85YWNqLWtxb0VZcTUyODZRa3ZJZXdEVzdtazQzdzZtNVhXTEZwMW9FaDV2ODZ1QUk4QnQtRkZPclh2bVMxUDFlSTZieVlaYW4xVzBqNERGdkI2aGpmcS1HVnlhZnJ6S09kdzZPeXNRSE40ZHZxcVQ0bGV5c1B4aHc5VHAwck4xekZ3bWNwRTlaazJ5TzlpS1RJb3A1dy1aQVU?oc=5",
+        "title": "Law enforcement officers remember police officer killed in CDC shooting in Atlanta - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxQcG1HN05JUzF0SGF1QkgyS3lmc0R5dFh2TWZ5U042YjR5ZnRpRzFOTGpPSC1PYmZGWDJJQWhudjRqckhzeUZYR0pCdllXRjZGRGhPMnNid2I5cGtMVHhoQWRZVjhIT2I3TDNtOW5CRWMzZ1ZvaElSVXFSbkNQV0JPM1oyOXFFTG9QckpDR003dkQ3M3I0SmhuRS1IVXB0dDEtUE5wVUx1SW4?oc=5",
         "description": "",
-        "pubDate": "2025-08-23T01:34:00Z",
+        "pubDate": "2025-08-23T02:34:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Are young women more left wing than men - and, if so, why?",
-        "link": "https://www.bbc.com/news/articles/cqxg89jzvl1o?at_medium=RSS&at_campaign=rss",
-        "description": "A divide appears to be opening up between young women and young men in the way they vote and view the world.",
-        "pubDate": "2025-08-22T23:48:35Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/e48a/live/1df3d340-7f82-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "North Carolina Supreme Court says bars’ COVID-19 lawsuits can continue - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxQTUlMZHhIR015Vlp6SVNwXzdZai1FT1dRR3VnVEFsWlNTaWpYYzIweW9WNUJjV3pJRFY5MWlGdXp0YVJINVZHdldMMjBTX2xnVHpiWlZaZXVkTXlXMHNnU281OVlmZGNfdjRHOTNSVWxCZW1fUU9xUl9DbVBUWVdRSUZNOTlBeHhKRXRpZE5qRGxVc2VuRkoxVHlPdnlmVUtvLUNKbkdMS19TeDFHbjV2YkJxZmk?oc=5",
+        "title": "Parents of missing California baby arrested in murder investigation - AP News",
+        "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxNZVdSaEk2bjhmNFZDUkVZbHBZdGp3eWpvMjVWbDQ1YVhEUjJWeElzR1Fsb0ZUV0E1ZW9qMFM3YW82N1J4TVNleUZSUWRrWmx1RmtCM01hSEQtY0pFa2pwb185NXlJRTh0S1BSdHdrc0tERmhjbHVOamhkSDNZOXdvZjNiQVlkYUx2NzdVT3EwUjAxb0VVRzVQYUJuejU4SlB0TVJGakN3?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T21:56:00Z",
+        "pubDate": "2025-08-23T02:07:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Former UUP MP Rev Martin Smyth dies aged 94",
-        "link": "https://www.bbc.com/news/articles/cde3p2450nwo?at_medium=RSS&at_campaign=rss",
-        "description": "As well as representing Belfast South in parliament, he served as the Grand Master of the Orange Lodge at the height of the Troubles.",
-        "pubDate": "2025-08-22T21:54:12Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3624/live/363ad890-7f9b-11f0-84a2-0722ea84f1f9.jpg",
+        "title": "Judge blocks Trump from cutting money to Chicago, LA and other cities over 'sanctuary' policies - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxNS05QaXdnSGZfeHBjY0RwaEp0NUJUOUZLRk03RG1uaUl4bm5XVnBPUzJmN0J5S3Q5Y0o2RnhXaHYwaFdlNXRPMnJUaUMtanZ5SnQxQUZoZi1QRWpsb0U5NHRadnVPSXpzTjhUOEFUcEFXLWtKLU40T3RTX3NydkhjOUJROC1OUHNrWEFxaDlIR1N1UWtfSkMwWUszbUZ0V3BnODlqNExNUnVIQ3VUQlBDYkh4VQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T02:02:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Tour bus rollover kills 5 on interstate highway in western New York - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiiwFBVV95cUxNX1lEaE01U0hMRUl0dGYxcTl4MHFvNGRPcnNkV1V3OGlQOWhHam43NnR0emcxTW80bDQ4LWxaSkNCQjVKbUFxWl9tanNZUWJraURjWlQ5YzRvTkRCUEdOTFE1RnpsMHdqeFRZUVNuSVlaQTRUM2VOdXRQQlZWZzV4QXJxZ2VyMFQ2YnNJ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T00:52:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Israeli defense minister warns of Gaza City's destruction unless Hamas yields to his country's terms - AP News",
+        "link": "https://news.google.com/rss/articles/CBMivwFBVV95cUxOODh5OHVDU1lfRkl1UDNyYjVGekd3ZC1YdmFFQUdUVDc3QjhsYjZ5aWJYZlltaHJ3YmJsMktkSWVIWDFUZFgyWjZFWGFkblZmMXduY2dYclEyRkJTWUktbklBNVFFbDhWSy1LcWxKeHFJVzBpT0FJTnNERzZ4N09qYTFrUkxNOW0tb2tXNmt5MThmVjZxMmlTNThueGlyVlNycW8xbXlkWFZ5azVMY3R3YzBoRHFLRTNuLV9qekJKdw?oc=5",
+        "description": "",
+        "pubDate": "2025-08-23T00:38:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Adrian Beltré now has a statue in Arlington to go with his Hall of Fame bust in Cooperstown - AP News",
+        "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxQVVRRdkZJbURyUC0ycjhLamdBTGFqRUpoQV9wOWJTcEZQSDdrNUJHS3J6aDhaTVR0UnlaM0NQQW5PVmdtQ3Q2Z0g3c3EwcllIMGJnS3RMR3pfWEZSWi1CUEtHUXNoNUhQVTc5WEhiZW1UUndjLUV2cnVDVUpTd3NUWnNsQk5ndXhDSnJ1aF9KYmVlQQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T23:40:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "California’s long-delayed bullet train slated to run in the Central Valley by 2032, report says - AP News",
+        "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxPZHNLcWRfRVQ5YmNzYWViLURJcnhkdEptWXJiWXc3aTRhX2Z4SUNRaFFSZUlNR0w4cU5NZHFpOUtjRXNVQTk3bWxwQm4tR2hzTk9wd19tVXBCamJhWlVqelM2cXktdTIzTU4yX1lxOWhzaExmTGpwanAzSUtuTWZESVNRODBTMXN5YTUzS1JKUQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T22:57:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "What’s next after a court cut Donald Trump’s $515 million fine to $0 - AP News",
+        "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxPTzJXd2ZVMDdfdW5ITV81WDg3ZVFFZFoxQkRaY0VLQ203M2RNczF4QXYxYUpyMTRxTXNxOXhONkhHX1V5N0RNMDN4Q2xqRG9LbmNsLVMtcE1la0VTNmJyYnVRN2p6M3pRZHRqdWdoUkpCb2pyR2lCV2d1TVZMQXRESXpPcnQ5a1BZblBlTzRMR01oRHFzLUMw?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T22:41:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Don’t fret: Air guitar world title returns home to Finland after 25 years - AP News",
+        "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxQWlBTWUI5M0xlQVo2ZDcwYXpHSzlzbVJZWFVjOWNOa2NENnpJeXhkUW5WS1V2UFN5bVVfdElYN0VyZmlrMXEtRDZqdjBwNjJxaWdvSFhyM2kxUmJ0VGNrVU11c3RLRDRabnlqOHBma0ttemgwVjBKSHh0cWZ2eF9DSUNBSF9EZGZsZmdLeG96UEZZWEFLQ19IN2VJUWJYa0lha0JNVzln?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T22:16:00Z",
+        "source": "news.google.com",
+        "image": "",
         "bias": 0
       },
       {
@@ -657,6 +313,24 @@
         "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxQTjR3LU93MFowSFN3ektYekhQVk1JQ2pHYnhjdm80Rmo4Ty1NYlEtN1lGZHNUN0VaM1pPVGZtQXdZTm1laGR0MG5kWlBzeGxSVFlPNFRTMkVJVVZYWTFjaTZZS2VnTElvYlFBQ1Z3enFLNjJzUTREOHBtLUVRMi1TczZCQnJjd0R2ZndfbkRXbGJXcndwd0pMUHRBZjkyM3dZV1RHVnZB?oc=5",
         "description": "",
         "pubDate": "2025-08-22T21:51:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Justice Dept. declines to defend grants for Hispanic-serving colleges, calling them unconstitutional - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiiwFBVV95cUxQb1o5MVV0UkN4TkFFaVhlRzBxbzJlY0NJR2JTTWduVXBkSXkwMXBWOVNXclIyTE0tTTFYUGZ5czhpWlZvUXIxdjVsWkRZRGo2MnFWUU9QNUsyYUlFOGpKbU9iVm1HWTl4WFgtRE9LTVgtREgwUmo3MGRnUm1wcEVNVjAtaXE4ZFpvaWxv?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T21:30:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "HHS moves to strip thousands of federal health workers of union rights - AP News",
+        "link": "https://news.google.com/rss/articles/CBMif0FVX3lxTE1heGlOZW9oYldGNzBieXpfYXRGODVzZDdWYllPQjMtRmM2S1JDR29tQm9TN25FMUZMMlRiTEFtek1ZX0JYM3c5Y1JEbGRoa1NMU0c3ZnpRdTB2WldncjhhMkdTUnh5YkJQMFZXd3VvZHhjRzh3bDdoaXA0bUxzaTA?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T21:25:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
@@ -671,6 +345,15 @@
         "bias": 0
       },
       {
+        "title": "Canada will match US tariff exemptions under USMCA trade pact, Prime Minister Carney says - AP News",
+        "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxOMkRGSzZQa1lLQzJSdUhYZGtDT3BGSm5KeG1FZWVQR2o3dVZIelItaDZjalJWR2RybWdicnhLdE40c1BrNGNZYnlEZVdEN201TEU5eS1fUUdtLUIwVDhCalpUNXhyQ0o2dGFSZGROVTBud1VIbzhEcV82Z1l1UHpleTBHbklJSllQTVF3OUJlUEVBNmc?oc=5",
+        "description": "",
+        "pubDate": "2025-08-22T20:34:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
         "title": "Coco Gauff hires Aryna Sabalenka's former serving coach, Gavin MacMillan, before the US Open - AP News",
         "link": "https://news.google.com/rss/articles/CBMiqgFBVV95cUxQMzI5MUIxVWVKYjF1YUpHX1d3VnZNUGFNTDJXWV9oX1JKelFMaXMxM3FWemxrUGpGdDhQaXlFTVVtZFluUEdPUkNEQlNoX2JGczA4U0lRRkx0N2xhb1dueDVzTnFtWmZUUVhwdzAwQlMyRnl4Y3BlanhnakRTa0ZyeExrYTJ4cGNPZWRMdDRfTEtMQWdvSlE0WW5EZ1RzdzB0d25jZHN3RTVtQQ?oc=5",
         "description": "",
@@ -678,42 +361,6 @@
         "source": "news.google.com",
         "image": "",
         "bias": 0
-      },
-      {
-        "title": "Intel will give the U.S. government a 10% stake, Trump says",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5509673/trump-says-us-government-will-take-stake-intel",
-        "description": "The president's highly unusual announcement underscores the Trump administration's desire to take control over U.S. businesses.",
-        "pubDate": "2025-08-22T20:17:14Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Texas and California advance in their reshaping of the national political landscape",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5508870/texas-and-california-advance-in-their-reshaping-of-the-national-political-landscape",
-        "description": "President Trump initiated a redistricting arms race when he urged Texas to redraw its congressional map to boost Republicans. It's part of a broader trend of Trump pushing the limits of democracy when it comes to consolidating power.",
-        "pubDate": "2025-08-22T20:03:06Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Costa Rican president appears before lawmakers and denies corruption allegations - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxPbm51VGdjaVh2WGlRa1MxVk1LcGZMeTdUSVdtMDg0d2FCNTdqU2U1S1V0bEVCQUdnb25PSzdUX3ZWbzZWNDIyME1pZV9vNjVVT2JXVDJkMHpJMFI3U0hYYWlpZlN5b203MjJXWU14OFFRSDFTeXlJNkh4Y19ad0FiMC12d0ZFRjMxMTVuTFl2VHRwUQ?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T19:54:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Justice Department releases transcripts from its conversations with Ghislaine Maxwell",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5494553/epstein-maxwell-doj-interview-transcripts",
-        "description": "Maxwell spoke with top DOJ officials over the course of two days in late July. Asked about President Trump, she said she had never witnessed him \"in any inappropriate setting in any way.\"",
-        "pubDate": "2025-08-22T19:40:40Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
       },
       {
         "title": "Photos of FBI searching the home and office of John Bolton, a former Trump ally turned critic - AP News",
@@ -725,237 +372,10 @@
         "bias": 0
       },
       {
-        "title": "Rockies release struggling pitcher Austin Gomber, a big piece in the Nolan Arenado trade in 2021 - AP News",
-        "link": "https://news.google.com/rss/articles/CBMijgFBVV95cUxNQmh4dEdwLWlBOGliUnBoUFRicjd6Q2ZZTFZsM2FLaG1YcnJoM0hlNG9IMW4yVDJFa1psTURyckRoM3JlWGxqaEthTklNWnF5UkJ0MTZ5Q0J2UlFySFJDaVVzVVVrMTdETzRZb1EzeVlWdXVqVmZLbmtieUp0VUg2TjI0MjNKNjAwVTh5SFFR?oc=5",
+        "title": "New York City allows robotaxi company to test autonomous vehicles in Manhattan and Brooklyn - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiiwFBVV95cUxPb3A2RlRhSm5oa3Ezdjl0VlNycXdCRXQ3My1ybUNaR28xNUNwaWlWVGJQVnMzRHAxcklrZVAtWUVYMTRBV2lBN2ZqWGZWTUxKaDBpXzA3bFEtWVhfSTk5ZzM4aFVEZElGX3FrWWdNckZaNFJRRnktbWFWSmNWTC0zcE5sWGhienJIaks4?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T19:24:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Home Office seeks to appeal against court ruling on asylum hotel",
-        "link": "https://www.bbc.com/news/articles/cy5p2ye95z9o?at_medium=RSS&at_campaign=rss",
-        "description": "The High Court refused a last-minute request by the Home Office to intervene in the Epping asylum hotel case.",
-        "pubDate": "2025-08-22T18:15:24Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/032a/live/93384dd0-7f4f-11f0-ace8-c7fe3706c172.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Business magnate Lord Swraj Paul dies aged 94",
-        "link": "https://www.bbc.com/news/articles/c0r72nj11kzo?at_medium=RSS&at_campaign=rss",
-        "description": "Lord Paul had been deputy speaker of the House of Lords and chancellor of Wolverhampton university.",
-        "pubDate": "2025-08-22T16:44:30Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/74bc/live/c7e4f880-7f6d-11f0-aed6-a9b9ead85975.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Trump embraces tough-on-crime mantra amid DC takeover as he and Democrats claim political wins - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxQYno2QXpad0R3Y0dYM1NtWVB2VVpjMUNtbVVjclJyQUVTWTAtNmJBT3pIcUVPNTZPSjRsdHJLbVdJenNYYkhrbkJscUViZTVNNzFOWVQxOFZrbGNVY1o3YVJCZXpaQlRENjl4cW9pZk1qUk03cGZxUS1tdWo1X3c1bW51d1FDWFRUVkR6VXpPMXBwNnlJN3ZJZHZ4Vml6bXFueTZQTE45NUtTT3FFNjl0bjdHYw?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T16:33:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "What are Rachel Reeves' options on property tax?",
-        "link": "https://www.bbc.com/news/articles/cm2k1m56xgjo?at_medium=RSS&at_campaign=rss",
-        "description": "Reports suggest the government is considering shaking up the property tax system to raise revenue.",
-        "pubDate": "2025-08-22T15:28:19Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/c9e1/live/23085c10-7dad-11f0-abdc-59614a74b023.jpg",
-        "bias": 0
-      },
-      {
-        "title": "What to know about China’s new regulations on rare earths - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxNMG5SeWR3VFRKU1lJcmphd0QzNVhOeFZmTjg1TFp3RkY1c3Ixd1BFMmhsa3lxbXMzSTcxaDM2WlQ4bXVfZWlsaUdxRFMyZlBHTXVPQjVTQXVqdWFnTlpfQ0hLSXFGZTY2Wk04MEh4UTAzWHNfVkNjZmRGSERmcWo5QmxNVTZSelZPbHdzQ0gtdHotT2lYcHpj?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T12:30:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Six new members join Reform UK's party board",
-        "link": "https://www.bbc.com/news/articles/cx291knwl3yo?at_medium=RSS&at_campaign=rss",
-        "description": "The decision-making committee welcomes Dame Andrea Jenkyns and three elected members to its ranks.",
-        "pubDate": "2025-08-22T12:27:23Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/45f1/live/5d1e5150-7f4e-11f0-ace8-c7fe3706c172.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Ngidi’s 5-wicket haul leads South Africa to series-clinching win against Australia - AP News",
-        "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxQN0JTS0R6LU05MzlZQ1M2OHVlZXQwYnJXVXdyVlF2bXRmRXh2OWdTMFc4VngxMjYwVTA2bkZzQXAwZlVic3NnOHh4ZzdsUk1pa21TdllDaG9Id2MwcWlid3AwYUQta0RMaG5Jal9IWEs0UWpiaXNOU2hjM3loSFVqN3B6NXJSdVREaS13Tllydw?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T12:17:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "UK's third-largest steelworks collapses into government control",
-        "link": "https://www.bbc.com/news/articles/cy0818y4jdlo?at_medium=RSS&at_campaign=rss",
-        "description": "Hundreds of Liberty Steel workers in Rotherham and Sheffield face an uncertain future.",
-        "pubDate": "2025-08-22T12:12:21Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/7dc4/live/c52bce00-7e93-11f0-bb23-61f665394239.jpg",
-        "bias": 0
-      },
-      {
-        "title": "MSP Jeremy Balfour resigns from Tories over 'reactionary politics'",
-        "link": "https://www.bbc.com/news/articles/c5ylwxwlpx1o?at_medium=RSS&at_campaign=rss",
-        "description": "The Lothian representative claims senior MSPs are being ignored under Russell Findlay's leadership.",
-        "pubDate": "2025-08-22T11:46:26Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/6794/live/8f43cd00-7f4d-11f0-ab3e-bd52082cd0ae.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Child benefit: What is it worth and who can claim it?",
-        "link": "https://www.bbc.com/news/articles/c5y3lyq28lgo?at_medium=RSS&at_campaign=rss",
-        "description": "There is a limit to the amount you or your partner can earn before you start to lose child benefit.",
-        "pubDate": "2025-08-22T10:00:14Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/024b/live/126688c0-7f31-11f0-ab3e-bd52082cd0ae.png",
-        "bias": 0
-      },
-      {
-        "title": "Olympic champion skier Eileen Gu injured in a training accident in New Zealand - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxQTjcySjZjWFJWVTF3UWJsTmNBZkJpNWJRU3R0YXkwUXhkN244RmlhMzZrOVV0bUxrN1hZVklUSF9MdzhyOFVHNGROZTF2aFFmQUlCSnN6SWVZLU9iMFBsc25UZ3V3NU1QRTVfVUJJeUhYOWYtaWk1b2hCc2FkT2FWSWhDRFhrLXJXVHdPaVd0UXFCZw?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T07:57:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Thailand's political path is shadowed by the ongoing dramas of former leader Thaksin Shinawatra - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxNVFVMMFFsMy1KRGtNNnRoZjJOTmlPemV6R2lFZEptWVVmM212c1RoVGlTN1NyOTRjaUI3Nk1CeGdSSXZDRGdGc1A5RjJpU3BYT3JJLTZ4WWlIWi14elBmMzFDNXh1a3JJZGdCS1FjcVNVejl0bTNacW43QnZUTEhKSjlYaDQxZUJtR1Nxc09qZlgtcDRXVW42WlQxdXJNRTFuOE9kRk9MMTdwRXhf?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T06:10:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Crackdown on child benefit claims from abroad after £17m saved",
-        "link": "https://www.bbc.com/news/articles/cr5r1zpl39jo?at_medium=RSS&at_campaign=rss",
-        "description": "The government is expecting the move to save £350m over the next five years, after a successful pilot.",
-        "pubDate": "2025-08-22T06:08:53Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/720d/live/b1b19560-7eae-11f0-a5e2-236e16f99597.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Giants' Jaxson Dart clears concussion protocol after taking a hit in preseason game vs. Patriots - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxNVHYxUEpKZXJIc3lqSkNoV2RmX1VJOHdWZXJtR00xWm4waGsyTFptUXBZTmp1RW0xdlJlVUltQ3I5TURqaWZFdWVrQmJsbG1kTE43RFgzbl82b2J1VTJSTUdOdUVDZjVJdFRwOXZjemNEczFFdnQ3YV9XaUlORVZXYXlCVE4zYVBEdE9NVGV6Yi0wWDI0YkE?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T04:10:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Another US military mini shuttle launches on a secret mission - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxQcHc0dVZtRG05Y3FJM2hQWkhJUm9UWmlOTkxJSUF4MG81Nm9CeE9IVGlDdVcxRmRKRURDYWJvZnE1MXMxQUtYVENjQlFUS2pIR3VmZUFNUlIzMGNfVnA2WHY5c3Vmb0I4cmFjaWtxaUxnMG9wMjhMZW4xcUhZY1RVd0VvUTkya21jenV0Yno2MVFYaEtROEE?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T03:56:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Defamation case against Fox News highlights role of its hosts in promoting 2020 election falsehoods - AP News",
-        "link": "https://news.google.com/rss/articles/CBMipwFBVV95cUxQMkVrYTNXV25SUUM2a25hTmptZHAwbmZ3MnNJTmRsOUU3c0hxQURwQWI0eWVBN0ZuWDFlWE1fU3J3WW5VVFlZaGluTjFoaXZ4YlBGNmdqcGpjVWlyeHA0Tnlta05DVnB5YnpheC15WmVBekZ6Vmw3RzBhZjNwWnByRVZqS0hFODJOR3RsVDlFeW01SmpMcDNCRUZ3X3l2LS11N1RzSng2aw?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T22:54:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "US home sales rose in July as mortgage rates eased a bit and home prices grew more slowly - AP News",
-        "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxNUFpROUl1T0JGeXZqVWpvRHNOWExWQlBKVTJoVEN2a3pZd1A2YXRQb1dtbEVhQTBJQ3BEeTRkdWROZHlCQ1c0OWVqcmlfckdxd0RQU2pmUkdFUU14YmxmX1RQZW1UQ1pmU20wNkdHcUN4N19YZkFHUnU1N0c5dVlCVzh1cXhqdzBfUkU0ZGU2bjZGWFBQaXhlanU1MXdnZ0pEZHNnRw?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T21:44:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Missing woman's body found in California forest and detectives say her husband has fled to Peru - AP News",
-        "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxPa3dHTDMtOTVxeU12Z3FuTE1IVjcwY2k2YTBfanVLQWhDT3pWbHJkQVNOVjJMUWJhNlpvWURnd0ZFcE90Y0NtQjBXb2ZDS25qYy1ESGJTWkdCR3NBcUhQM0tGdWR6YlZTZVlmdWwtN1NGenB1c2ZLb3ptamYwNEpqNzZZNHloa2UyUnVhWFJIbzlrY1ZjUUlYOWlPQQ?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T21:32:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Record 111,000 UK asylum applications in past year, figures show",
-        "link": "https://www.bbc.com/news/articles/cwy1kxv8xewo?at_medium=RSS&at_campaign=rss",
-        "description": "The latest data, which covers Labour's first year in office, also shows the government is processing cases faster.",
-        "pubDate": "2025-08-21T17:41:08Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9d5a/live/c81e1580-7e9f-11f0-9b5a-93b6ac298424.jpg",
-        "bias": 0
-      }
-    ],
-    "Tech": [
-      {
-        "title": "Women’s Professional Baseball League launching in 2026 offers new hope for athletes - AP News",
-        "link": "https://news.google.com/rss/articles/CBMifEFVX3lxTFBvQ19JemliYTdncnJqVmpycEtqaWNLNEtGYWtYVF8xNVFCUk5STEJ3Wms1NFROeGVpNzhZd045UmtqcXJXckxQb0xUOFF2S05FRHZ0cGYwVVhjSUtrNE4xdEc5RmdGVXFWampkMTFCTm1UNkpPSXRlSXE1WDg?oc=5",
-        "description": "",
-        "pubDate": "2025-08-23T23:28:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Bubbling questions about the limitations of AI",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5509946/bubbling-questions-about-the-limitations-of-ai",
-        "description": "NPR's Scott Detrow speaks with Cal Newport, author and computer science professor at Georgetown, about AI's limitations and if progress within the industry has stalled.",
-        "pubDate": "2025-08-23T21:20:20Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "What to know about visas for foreign truckers and the politics of a deadly Florida crash - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxPbFVSNk90UUF6bTZlM0xSV09aZUZEelJoUDVLQnhseGZIZlBtQUVtRURXNVFwU09QeTBOQ1BtOUhIMHZOM3BPLVRZcVhlVEFCaVN0SUc4TXhncVpzVENpVXIwRjRzWmEySHJ1S090UmNFekhuUG93aGZRd3MtM1FTRC1fWXh3dXN3ZGIzNng3MVFuT1pSLWh1eU1RX2VJT1RiTEVLb3hRaUI3WjFC?oc=5",
-        "description": "",
-        "pubDate": "2025-08-23T17:33:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Trump's new RNC chairman Joe Gruters is a longtime believer. Here's what to know about him - AP News",
-        "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxOOHFUaFJFdnZKX0otTGVUMFBxRnVrZUhDSmk5cWltVzg1Nkc3T2JFMWZoZW9rNzlrd3l0UHRsM1pJcFQzazNPdENQV0MtakFUaHg1UzA3QjhKLU9YTTgtZjFaUkFvWFExZFFxNENmSmNPXzNkRXlOYzRpV1poYkJKRklXYWU1YUY0eDBFZWJvNXBQS0FCTzRRRmp3ME9zSUV2bTZhWDBB?oc=5",
-        "description": "",
-        "pubDate": "2025-08-23T01:04:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "My ex stalked me, so I joined a 'dating safety' app. Then my address was leaked",
-        "link": "https://www.bbc.com/news/articles/ce87rer52k3o?at_medium=RSS&at_campaign=rss",
-        "description": "Thousands of women who signed up had their data, including images, posts, and comments, leaked.",
-        "pubDate": "2025-08-23T00:34:38Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ed31/live/ff719070-7f71-11f0-8844-df46f3a0217b.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Small Minnesota county bucking national news desert trend, has 3 family-owned newspapers - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxPSXBoYm1CS3hEWWx1SnhNMGtmR0o2UldDejRtblA5RnZwYzlTMWdzUzB3YnhJM3VmYkZGMlhwUnRlM3JFMVRHTWtHYU5KOVFSWXBDVy1lcWo4eDlwb1VJbno0clUzci00MXhqSzB1YjY1NTlxdzNPSjV1SDlJYW5VWE5wV1NENnBRQkE?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T20:13:00Z",
+        "pubDate": "2025-08-22T19:31:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
@@ -970,1745 +390,969 @@
         "bias": 0
       },
       {
-        "title": "Apple TV+ raises subscription prices worldwide, including in UK",
-        "link": "https://www.bbc.com/news/articles/c1le9l6pee5o?at_medium=RSS&at_campaign=rss",
-        "description": "The streaming industry has seen a series of price hikes from its major players in the past year.",
-        "pubDate": "2025-08-22T14:22:32Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3f59/live/537007f0-7f69-11f0-aed6-a9b9ead85975.jpg",
-        "bias": 0
-      },
-      {
-        "title": "TikTok puts hundreds of UK content moderator jobs at risk",
-        "link": "https://www.bbc.com/news/articles/cgjyp48dp21o?at_medium=RSS&at_campaign=rss",
-        "description": "The firm says it's planning to relocate work to its other offices in Europe and invest more in AI.",
-        "pubDate": "2025-08-22T12:32:06Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/48cb/live/bf0a5f30-7f4e-11f0-ace8-c7fe3706c172.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Elon Musk and X reach settlement with axed Twitter workers",
-        "link": "https://www.bbc.com/news/articles/c1ejq154nqzo?at_medium=RSS&at_campaign=rss",
-        "description": "Ex-Twitter staff sued the platform after some 6,000 employees were sacked in 2022.",
-        "pubDate": "2025-08-22T02:51:40Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/acf2/live/016cfda0-7ef6-11f0-9d8e-d573e47ef33d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Netanyahu says he will push ahead with Gaza City takeover and renewed ceasefire talks - AP News",
-        "link": "https://news.google.com/rss/articles/CBMivwFBVV95cUxOR21UN1RZY0tfTGlnbkJLSUZHUmdPSEFlTEU3YXJvck1wSFVQLWlaUEx0NjBTbFNNSDk1UTBsNDEtTERzTnFSN3U2SlVPMnQtR0ljdzJiay1DTHpxUk1uUnpNdmtnLUtoanJSOVEyTDlja2JwS1NfWlRicXEyS3JVTWxCX1FmQjNqbFc5TWJhYVNVZXVuTmpKZGU4Y04xRThmRVFzMkFzb0R6a3lYWnhUQ3BSNXd4TGtWcC11UDYtZw?oc=5",
+        "title": "Sebastian Korda is trying to get back among the top American men at the US Open after injuries - AP News",
+        "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxNUnFZWEhNcTlNVmdUYzIzQzhqN2N4LU9mZF9kRjFZb3VycmVxaFlEOFVjaDYtSjFZeEpPT1VXVWo5Z0dHbzloNGZ0SnM4U1VRWjljUXFpSDVtS0xKUWJhZGJrekxFbFZSTzljcFdSTDFCUllPM0xVWHpmVV9TekFQSXZZaG1QcWpZdnRkUGd4OGxvUQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T01:41:00Z",
+        "pubDate": "2025-08-22T19:12:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Trump’s crackdown in DC leaves residents on edge as federal agents set up checkpoints - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxOSUhLZkVzSk1nZ2RUSEoydXRhenZCYUpTUTZIOUtqSWdQMXk3cXNwaW1kN2VzYzZCMWROS3RkM2JtbVZzc1BqVmhSS2ZlbDdLUTl0THg2QnRXUlE0Sng1Mjl0c2NRSXJZOWVOZW1tTXExLXhZTHNSMjJmSGhITC1Sdi1nRElYRHZHMzhOWTFYMzdZa1VPSElNSGRqZ1FsS2FhMWhUSTNTYU54OUlJQU13LWZLTXh3ZGEtSUE?oc=5",
+        "title": "New Orleans Mayor LaToya Cantrell has been indicted — what comes next? - AP News",
+        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxOVmRtLV84YmJiOXFxaXFmZV9PRHJ2TmVIX2JyNzNNMXRRR0U5TU5EYkZPeldjT0p2bmRlSGNSdmNaOGdXVGlqWlVVNzQ0bEk1VVYtZjBNRU1FcXkyTV9BM0taU3BkNE9Ga3dqdDlaT0N6Smc1ZEJVU3kya2NZNnR6QWFSUkRfS29XZExES1NyUmJXdHVDWmw3ek5Dd2E3LUJ5MF83c1lmOXVlUGZo?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T00:56:00Z",
+        "pubDate": "2025-08-22T17:59:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Supreme Court lets Trump administration cut $783 million of research funding in anti-DEI push - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxNOE5kNDcwM1NUejdMMVVCSjZrLTZiYUNSV2xjeGtjQmJMc1liNm1RLUl0VkRpNXdubW54QndMZ3dPci1xSV9xZmFaLU1qMFJvRE4xQllOLXVRYm81aUtYd191YlcwdTNLRmoyRTA4Zko2NVJoZUlxTVgybUJvSmpPdi1GWE80WkZsaHVWTm0wSWE?oc=5",
+        "title": "Pop Mart rolling out mini Labubus and a long-fur version of the popular plush toy - AP News",
+        "link": "https://news.google.com/rss/articles/CBMilAFBVV95cUxQU2c2VGllR3N0V2ZDaTEtQVF1d0pzUkE2VXdxTjhCSDZwYUh3eTdtdEtKNlFoWFNzMjR4RmsxckZiN0UxVHh6TTZTYjJRZHR3RDhuakRROWRvdEtHZnl6dGEzYVB5UEZ4Q1ZkcGlyQ2t3eFdEb1FlVWliMWVoUjRfUk55ckdXRDhmMUx5blRPeXhGZFFt?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T00:06:00Z",
+        "pubDate": "2025-08-22T16:53:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Computer science graduates struggle to secure their first jobs",
-        "link": "https://www.bbc.com/news/articles/cm21dvg8l1go?at_medium=RSS&at_campaign=rss",
-        "description": "Companies are using AI to do basic coding tasks instead of hiring junior staff.",
-        "pubDate": "2025-08-21T23:50:34Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/0a1d/live/65f24b40-7767-11f0-8071-1788c7e8ae0e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "4chan will refuse to pay daily online safety fines, lawyer tells BBC",
-        "link": "https://www.bbc.com/news/articles/cq68j5g2nr1o?at_medium=RSS&at_campaign=rss",
-        "description": "The online message board's lawyers say UK safety laws shouldn't apply to a business based in the US.",
-        "pubDate": "2025-08-21T23:45:55Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d789/live/a6b26a30-7e96-11f0-8884-75e02e8a067a.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Trump blames renewable energy for rising electricity prices. Experts point elsewhere - AP News",
-        "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxNUmZPX3BFU2k5d3NDTlNSZUlwTGRGcFo4UTRrdjU2MF9TOVZrWXU2YTk2NEFhY29LbzJCNTJRYjRhY2NrSEdyWVNSQnFaOWk3eG5NNzFBNG9qeFNlQTdkeE13VGtKaElGN1Z2VjJlTGJXS1ZzN2FrdmVqb0YyS3UzM2hmZFFUdS1wYy1kR253SzI0LTB4LXdxSnc5dw?oc=5",
+        "title": "49ers bolster injury-hit backfield by acquiring Brian Robinson from Washington - AP News",
+        "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxOUlQ4V1l4WVNJSXJ2a3NaVU4walRBWmgyOEZpeWVUOXhFeHRFVzRwTzM3ZHpjLS1oNXpKSHJlSnpyWnBxZUJ5VDRfY1FReEx0VkJYRnpFWUo5dlJHUVp1cmhjaWlHN0NPS1JoQjg3SFNHbFFDRnV4T05xWVlNbndvd3hPSnhQNHJYU3FpY2M4dHJ2WVlFaEE?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T21:42:00Z",
+        "pubDate": "2025-08-22T16:51:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Brent Hinds, former Mastodon singer-guitarist, dies at 51 in motorcycle crash - AP News",
-        "link": "https://news.google.com/rss/articles/CBMijgFBVV95cUxQLWduYmRuZDB6TTBJcFBhcXdBNEEzd0lSSWhyUFlSUG1QeERmY3NFMFVLVlBoblB3dkJTcTdDQW8zZlB0WkN0dmNMT1dQMXBPQW1wUFQyTnViRXF0MktEOEZvSHk1TzY0U1FjU3JSLW5CVS1uX0dyQmROcWRVSXNUMmJuT001aTJYZWN2M1dn?oc=5",
+        "title": "Trump says he’ll keep extending TikTok shutdown deadline - AP News",
+        "link": "https://news.google.com/rss/articles/CBMingFBVV95cUxOZXNOcjFOV0EzcmFBZFNMeU9CY3otQXQtbWNveDBEYnJHSGYwdVMtWE41azZOV0VFSUdZM0FwTG1tek9SRTlQSnNCZ3NuSFJLbWFnSGxBd1l3R2FJRnRmZEU2VGU5bG16X0RaMjVNYm1rU24wdW50ZExKUlM1OHFGclFSSmNYTzNnLUcxUzFMYXJZQ1hiNEY5WkcydG53QQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T21:25:00Z",
+        "pubDate": "2025-08-22T16:47:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Uganda agrees to take deported migrants from US if they don’t have criminal records - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxNMG5mNjlFbTZpdmFVTjVsd0hEbWRfUHdfN2Njc1BDQl9DVDBPNlBuWDlGbXBOTE1OeFB5YzMteFhxS25ZRzBkVlhYN0lHcXBHaGpzVkQzWnNmaUh0VlFSSWFfS0xocW92c3N2ZmhkWWhlbzZwVHpEWUk2a2pOdnZZNldIOG9YWGFSVUJPbjM3WGhWckhGbml3RTE0NW9CdzJhN3pXWERYR2ZVSUFSNmJyTnZZXzU0cE4zaUE?oc=5",
+        "title": "What Trump’s crime crackdown in DC looks like in photos - AP News",
+        "link": "https://news.google.com/rss/articles/CBMitAFBVV95cUxPckJsMUFqN0hsNFNzeHRMbENfT25OWmpCUmhmWTVKSmZQRTFTVGctZ3FWN2VaRDlXRjg4MzhrMXBPd0thMlY2ajlWaTlkZjFvTHBQWjRjQU5TcU1KRVRPakZnZTNPN2JxUXcwdGplMHhSWUhFZXZ2d1QyOHhkek8wX1BRdk01OVp1bjRGbDhfLUY2RHN4WDE0cEc4NGxWam9ubVpsM1JnUm9kTGlqeGtSdHRGUzA?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T20:23:00Z",
+        "pubDate": "2025-08-22T16:19:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Proposed data center prompts Tucson to regulate large water users, require conservation - AP News",
-        "link": "https://news.google.com/rss/articles/CBMi2gFBVV95cUxPcGl1bzFIR2k1Z1VteTdPNS1SMXgtQlRYNEtJeUdWYjA1WkQ0Ty1IWWx4VU5NTVMzWlpfQkw4M0REV29JSEtsaEd4YkhwM1NHU2k2VDhaX3hlMkNUUE00eE9MdkxGbWZnVnVxdHdlMVg5NmQ3eG05NS1yek5WTmRMeF8wcW95Z3EtOGVZbU1kb3FNRkI2YXViTGRpbTB3TFZBVnRYaThhTXZPUHlNUkkyNXNqeDZ3eHVrelVwOFJLWFJTbzlHaXZRaHI2dzJ0aHoyUkVYWndlRkR2QQ?oc=5",
+        "title": "Through the smoke and fire, an AP photographer captures a man on a motorcycle carrying a sheep - AP News",
+        "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxPaGw3QUxqLTdWZ1RxTGFaYmpmXzBLdHA4aGNxdEtUSk40TnFOSk5oaXhTYk1mZmpYVjBmM01pRjdYRHNXLVNzNnhpQ1h0NUI4cE5VNXFwbEpvVkpSaDI4STRSQzBNQm41dTY2NlgtWHRicXhHQ09EazQ0bXZubFZHUFh4cENOd0JpRjVmYmhvdw?oc=5",
         "description": "",
-        "pubDate": "2025-08-21T20:21:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "A newscaster takes us along on her date with an AI companion",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5500249-e1/a-newscaster-takes-us-along-on-her-date-with-an-ai-companion",
-        "description": "Despite dating apps and social media advice, romantic connections can be hard to make. Enter artificial intelligence.",
-        "pubDate": "2025-08-21T20:20:25Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Andrew Luck’s return to Stanford football aims to revive struggling program - AP News",
-        "link": "https://news.google.com/rss/articles/CBMihwFBVV95cUxQUkZMem9mNmtwcm96QWlxNHAzOEdyay1lZEdaNjZsUWsyeWFSWjRIbk52d2lmMDJ2eG54MG9TZXd4MnhRUENwTzV0dFVuTFNWa3Z2RGwwN3VmcXFSWmhSRHRBcXMwTTlJODkwTEU2bk0xSHZWaDdRRXhGM05nZ0U0LUt5TzR1UzA?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T19:38:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Wisconsin court commissioner resigns after dispute over immigration warrant - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxQdHRwcXU4UUM0ajRRTU9qSjl2bWZkYVZZMEZqN1ByZzdpX1JmZ3pqRnJ2Qk02Mm9UWHEyR29iX185QjZwVUlPRFN2Sk1lU0I0bUhva3VidTJ6QWFVOWZCRUpONGZqMGxJcW9iY2pQNkRSVml3b2xvTl9LQzhBTjQ5SE9kQTBRUjQwMFBDUm9BNFI1TURfZnRXc0Y1aW5nN3pnaFNJSGJ4YnZ3djJBWWZrRGp3ZnlibDI1SWc?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T19:06:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Michigan couple sues resort company after Mexican prison ordeal over timeshare dispute - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxQc2Z0RndJTnctdnpsejRmMVRydDVVSTVvWExIVFVaaS1sMTN0LWpnTXg5MlFtRVdDTFdFOVM4SHhPaHQtZGFyemlPSkl5dTU1UlVMWk4wVEJxaXhDeVp6TzI4ZVBWU2J0U19XWUZUTktDQk5ycjk3djJoWm90aklJcnYzX0o4Y1RUZ3ZYTkJRa1ZTdUhNcGZpSGVnQ3FULUdlVmV4ZG9Vb18?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T18:43:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "French streamer's death 'not due to trauma', autopsy finds",
-        "link": "https://www.bbc.com/news/articles/cr4e1k6l4lyo?at_medium=RSS&at_campaign=rss",
-        "description": "The online personality known as Jean Pormanove was found dead in his home in Nice on Monday.",
-        "pubDate": "2025-08-21T16:47:26Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1cd4/live/b8185d70-7eaa-11f0-96de-5db50e919182.jpg",
-        "bias": 0
-      },
-      {
-        "title": "A Ukrainian startup develops long-range drones and missiles to take the battle to Russia - AP News",
-        "link": "https://news.google.com/rss/articles/CBMinwFBVV95cUxOVXhlbVlvODdVbHM0UEJSRUUzUzhVMWc2YVRfcm5IUWYzOEZBX0xZOHhjSjhGaWEyQUVqZ3ZVQy1VMjJKSTVWTkx1XzFTMWZvSENLY2RVSjFoWVkwZzFPRHhBWk5ZdmhMVzAxdEpneklEdGxDWEx2Y2djanBudWg2ak5GUUJRNnBnMUdjcU1Vcmppci1FMnA1cF80aGloMEk?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T13:13:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Hundreds of thousands of Grok chats exposed in Google results",
-        "link": "https://www.bbc.com/news/articles/cdrkmk00jy0o?at_medium=RSS&at_campaign=rss",
-        "description": "Elon Musk's artificial intelligence (AI) chatbot appears to have published messages without users' knowledge.",
-        "pubDate": "2025-08-21T12:55:28Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/7849/live/086fde10-7e83-11f0-9e05-3dbec5559644.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Netflix signs up another YouTube star with Mark Rober deal",
-        "link": "https://www.bbc.com/news/articles/c20939pp04po?at_medium=RSS&at_campaign=rss",
-        "description": "The YouTuber and former Nasa engineer is working with Jimmy Kimmel to make a new competition show.",
-        "pubDate": "2025-08-21T11:26:08Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/aee0/live/3a475b70-7e6f-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Investigation into 'horrifying' death of French streamer",
-        "link": "https://www.bbc.com/news/articles/c1mpjplk4pxo?at_medium=RSS&at_campaign=rss",
-        "description": "Raphaël Graven, also known as Jean Pormanove, was found dead at a residence in Contes, a village north of Nice, prosecutors said.",
-        "pubDate": "2025-08-21T07:51:05Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9433/live/df8ab920-7d33-11f0-b6c9-e1728577c12d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Prosecutors link LA contract to Smartmatic ‘slush fund’ as voting tech firm battles Fox in court - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxNY19JbjdZT3hoalpfZWJlVFk2b01GWkg4X1hNOXN2NlBWTTlUYnhfc2VodHAxV2lVMWphSE1jbnc1TnBrckJZemNzczVqdVBzeGpMUkJfTzFtZGE1SlRnWkRwTWFXVGJxajRtY3QxRDFKVnB6eFk1X200aUd5cUU5T1h2M3FSaGZWVGdGbjd0NEctS3ZPSGdjSDFGWVd6dXJLM3FPLXNzN0trUnF5R3RJ?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T04:03:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Sony raises PlayStation 5 prices in US as tariff fears persist",
-        "link": "https://www.bbc.com/news/articles/cy081prg9jjo?at_medium=RSS&at_campaign=rss",
-        "description": "The Japanese technology giant cited economic challenges as it raised prices for the consoles by around $50.",
-        "pubDate": "2025-08-21T01:45:10Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/789a/live/33576d30-7e26-11f0-be03-b746a15647b1.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Microsoft employee protests lead to 18 arrests as company reviews its work with Israel's military - AP News",
-        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxOQlpveGJxOGlNXzFtQlJQT0NfQlBBMWpvMllwY2NHVTFOdnZoWnNKWmNrUXBsT3BaMkNHVXVfZndaZGZSZGtDX3ZtaFZOeWY2bkdIQlMtZTlUX3BzNTZsQ3kya2Fwa0RRa09BU2VXbTFoWGhtQmlyTlpDN0dMb3J6cDZaYW5HaUVOV3pYZDRPU0pJZlBtY3M1eUMzNmE?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T23:04:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "At least 600 CDC employees are getting final termination notices, union says - AP News",
-        "link": "https://news.google.com/rss/articles/CBMie0FVX3lxTFAwcldOS3A1TW5yTjRMSV9STXZSM3p3MjBqaEJkbWRGanRUb3FlUGIteFkyWlRnX0pyVGVsYmVNT1htTkFxdGZVWFVNd2hIdkR1NG5VWjY5Y1loQVc1ZUZON3hHa2pfRFVjMlVDYWg5M1dZU1FSMDVUeVZoNA?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T22:49:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Judge denies Justice Department request to unseal Epstein grand jury transcripts - AP News",
-        "link": "https://news.google.com/rss/articles/CBMijwFBVV95cUxNS0VjSWQtVkNSUjFWblRYa3MzVU5yR1J1NjlRbzYwdmNHUmRCYlRIcnFCR2dZdmV1M0hHOXJsZGlrUW1jYnFRTktfWmNsdzRXRmdpbFNWbzQyRzUwQ2c2RlVJVE5FSFk5Rkt2NzJRZHpFU1NsUnljSWlCNHEtWkMwX0V1UVl0US1IMDhRVU1DRQ?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T22:35:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Target CEO to step down amid company struggles - AP News",
-        "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxNMnNiX0ZidmN5MDNNbTE3Q05XclpaSlAySFJyUkJ0YlBsUXhjY051WTYzV0dQQTdGOTlNb0V3UFlhdGI0QzVqUS1CTVFvTWxtY25tT3JYcFdFdDFkS3lEUmpkOGQ3WmZNWGRSQVhaUm5ILUZoOUN1anlfX0dUR0FLamtUMllnYmNaZFJQbDh1bHdibm95VnVOSHJrSE9nSnpi?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T18:39:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Microsoft boss troubled by rise in reports of 'AI psychosis'",
-        "link": "https://www.bbc.com/news/articles/c24zdel5j18o?at_medium=RSS&at_campaign=rss",
-        "description": "Mustafa Suleyman said there was still \"zero evidence of AI consciousness today\".",
-        "pubDate": "2025-08-20T16:36:03Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3cd8/live/925378b0-7e76-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Human rights regulator criticises Met's use of facial recognition cameras",
-        "link": "https://www.bbc.com/news/articles/c1kzgx4v2pko?at_medium=RSS&at_campaign=rss",
-        "description": "The Equality and Human Rights Commission says it believes the Met's use of the tech is unlawful.",
-        "pubDate": "2025-08-20T16:18:42Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ddf9/live/34046060-7db5-11f0-88de-21c2f8cb127a.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Trump thinks owning a piece of Intel would be a good deal for the US. Here’s what to know - AP News",
-        "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxNU0FzSU8xeEtYaGZPcU1ZUVY3TkNzdTZXQ0dNbUFrc29jVzZJMnpNMXp4RUFxamVQTXVhUVlLTVdSNmxwODNKLXJhSUVoUlRXVndUVXVydTRpVXpXYXJHaEVROXp6Qm9DOFdYcGZTM3kxZWlCd2s4WjFQZk44eEU0QWlJbUFxcjlaNVhXMkVyLTBpbzdUcVZSVkJWMzdNQmRxTk1FTg?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T12:03:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "These brain implants speak your mind — even when you don't want to",
-        "link": "https://www.npr.org/sections/shots-health-news/2025/08/20/nx-s1-5506334/brain-computer-implant-speak-inner-speech-mind",
-        "description": "Brain-implanted devices that allow paralyzed people to speak can also decode words they imagine, but don't intend to share.",
-        "pubDate": "2025-08-20T10:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "US in talks over 10% Intel stake, White House confirms",
-        "link": "https://www.bbc.com/news/articles/c620gg77epxo?at_medium=RSS&at_campaign=rss",
-        "description": "The potential deal could involve swapping government grants for shares in the chip making giant.",
-        "pubDate": "2025-08-20T06:37:52Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/e7c3/live/916254e0-7d58-11f0-a845-0926f58b08ed.jpg",
-        "bias": 0
-      },
-      {
-        "title": "UK backs down in Apple privacy row, US says",
-        "link": "https://www.bbc.com/news/articles/cdj2m3rrk74o?at_medium=RSS&at_campaign=rss",
-        "description": "UK authorities have demanded access to Apple users' protected files when required for investigations.",
-        "pubDate": "2025-08-19T21:45:56Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/52fc/live/19be9d90-7cdb-11f0-8600-6b5268f36518.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Tech Life",
-        "link": "https://www.bbc.co.uk/sounds/play/w3ct6zp4?at_medium=RSS&at_campaign=rss",
-        "description": "A special from Edinburgh, where art and performance meet tech with spectacular results.",
-        "pubDate": "2025-08-19T19:30:00Z",
-        "source": "bbc.co.uk",
-        "image": "https://ichef.bbci.co.uk/images/ic/240x135/p0lxrjcx.jpg",
-        "bias": -1
-      },
-      {
-        "title": "Research suggests doctors might quickly become dependent on AI",
-        "link": "https://www.npr.org/sections/shots-health-news/2025/08/19/nx-s1-5506292/doctors-ai-artificial-intelligence-dependent-colonoscopy",
-        "description": "A study in Poland found that doctors appeared less likely to detect abnormalities during colonoscopies on their own after they'd grown used to help from an AI tool.",
-        "pubDate": "2025-08-19T10:57:42Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "An AI divide is growing in schools. This camp wants to level the playing field",
-        "link": "https://www.npr.org/2025/08/19/nx-s1-5503984/ai-summer-camp-schools-education",
-        "description": "For years, research has shown a digital divide when it comes to schools teaching about new technologies. Educators worry that this could leave some students behind in an AI-powered economy.",
-        "pubDate": "2025-08-19T09:25:07Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Stop children using VPNs to watch porn, ministers told",
-        "link": "https://www.bbc.com/news/articles/cn438z3ejxyo?at_medium=RSS&at_campaign=rss",
-        "description": "The children's commissioner for England tells the BBC virtual private networks are a \"loophole that needs closing.",
-        "pubDate": "2025-08-19T05:39:49Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/7b00/live/9e373fa0-7cae-11f0-85ce-db24c25b1e67.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Intel shares jump as Softbank to buy $2bn stake in chip giant",
-        "link": "https://www.bbc.com/news/articles/cly4vn1nxg7o?at_medium=RSS&at_campaign=rss",
-        "description": "The announcement comes hours after reports that the White House is in talks over taking a 10% stake in Intel.",
-        "pubDate": "2025-08-19T02:06:02Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/891a/live/74e1ad80-7c8f-11f0-894e-df09709835a6.jpg",
-        "bias": 0
-      },
-      {
-        "title": "How to destroy harmful 'forever chemicals'",
-        "link": "https://www.bbc.com/news/articles/clydd630pxzo?at_medium=RSS&at_campaign=rss",
-        "description": "PFAS were once prized for their durability, but now firms are developing ways to destroy them.",
-        "pubDate": "2025-08-18T23:22:14Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/dc4e/live/67f0c250-76c2-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Meta investigated over AI having 'sensual' chats with children",
-        "link": "https://www.bbc.com/news/articles/c3dpmlvx1k2o?at_medium=RSS&at_campaign=rss",
-        "description": "The leak has led to backlash amid reports the tech giant's legal staff approved the conversations.",
-        "pubDate": "2025-08-18T12:04:06Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/34a3/live/36f25ab0-7c17-11f0-a40e-2dd630055bb1.jpg",
-        "bias": 0
-      },
-      {
-        "title": "What's behind the Trump administration's immigration memes?",
-        "link": "https://www.npr.org/2025/08/18/nx-s1-5482921/memes-white-house-dhs-social-media-trump",
-        "description": "White supremacist tropes and ironic viral jokes illustrate the administration's project of redefining who belongs in the United States.",
-        "pubDate": "2025-08-18T09:48:28Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Should Europe wean itself off US tech?",
-        "link": "https://www.bbc.com/news/articles/c3dpr2zkny0o?at_medium=RSS&at_campaign=rss",
-        "description": "Just three US firms provide 70% of Europe's cloud-computing, leading to fears of overreliance.",
-        "pubDate": "2025-08-17T23:03:19Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b764/live/d13e3150-7831-11f0-a20f-3b86f375586a.jpg",
-        "bias": 0
-      },
-      {
-        "title": "AI is driving a data center boom in rural America. Locals are divided on the benefits",
-        "link": "https://www.npr.org/2025/08/17/nx-s1-5461467/ai-is-driving-a-data-center-boom-in-rural-america-locals-are-divided-on-the-benefits",
-        "description": "Artificial intelligence is driving a data center building boom across rural America, including in central Washington. But critics say the centers do not produce enough jobs — and drain resources.",
-        "pubDate": "2025-08-17T13:02:15Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      }
-    ],
-    "Science": [
-      {
-        "title": "SpaceX prepares for 10th test launch of massive Starship rocket",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5514847/spacex-starship-rocket-launch",
-        "description": "SpaceX wants to put the two-stage rocket's massive booster through its paces. The flight test comes as the multibillion-dollar Starship program has suffered a streak of failures this year.",
-        "pubDate": "2025-08-24T20:39:15Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "The U.S. wants to mine the deep sea for rare minerals. Science shows what's at stake",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5455940/the-u-s-wants-to-mine-the-deep-sea-for-rare-minerals-science-shows-whats-at-stake",
-        "description": "Some countries, including the U.S., want to mine the seafloor for rare earth elements used in smartphones and electric cars. But other nations are concerned about the environmental impact.",
-        "pubDate": "2025-08-24T12:51:58Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Key things to know about how Trump's war on higher education has ensnared an unexpected campus - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxPWjdTUF8tSkNlVXBGN2VVQkdhaVVDT3pmNllsMnhYSHN3OG5tcG5iZnpmN09jS050dEgtVjdvSEo5YmdKMVNuUHBJcWtrRDdyRzZNdmtOalFXV1lYa1A1Y2lGVXVVai0wdm5aNGE1My0yYUo4WWxfeGlMeW5iaF9TMWVpM002S1J5YXBRd29KZjZhYTdna2pqVDFxVmhLU1J6QXJLUFZWQjRDY3ZSVXVSVWxFMA?oc=5",
-        "description": "",
-        "pubDate": "2025-08-23T15:29:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Hawaii's Kilauea volcano erupts again and shoots lava for 31st time since December",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5513910/hawaii-kilauea-volcano-erupts-again-shoots-lava",
-        "description": "Hawaii's Kilauea volcano resumed erupting Friday by shooting an arc of lava 100 feet into the air and across a section of its summit crater floor.",
-        "pubDate": "2025-08-23T13:36:49Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "The EV tax credit ends soon — but there's a little bit of wiggle room for car buyers",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5511244/ev-tax-credit-deadline-irs",
-        "description": "A federal EV tax credit worth up to $7,500 ends Sept. 30. But the IRS has just clarified that shoppers don't need to actually have the keys in hand by the deadline to get the credit.",
-        "pubDate": "2025-08-22T19:12:24Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "New dinosaur named after record-breaking sailor",
-        "link": "https://www.bbc.com/news/articles/c87ew7qq4wwo?at_medium=RSS&at_campaign=rss",
-        "description": "The medium-sized herbivore once roamed the floodplains of what is now the Island's south-west coast.",
-        "pubDate": "2025-08-22T10:45:09Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/bf3a/live/19cf2810-7f3b-11f0-b7ed-0b17109072b5.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Supreme Court allows NIH to stop making nearly $800M in research grants for now",
-        "link": "https://www.npr.org/2025/08/21/g-s1-84441/supreme-court-nih-grants",
-        "description": "But the court, in its emergency-docket order, left in place by a 5-4 order a lower court ruling that threw out National Institutes of Health memos that enforced the administration's policies.",
-        "pubDate": "2025-08-21T21:41:09Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "A new study challenges what we know about how amputation alters the human brain",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5506040/a-new-study-challenges-what-we-know-about-how-amputation-alters-the-human-brain",
-        "description": "Even years after a person has lost an arm, the brain faithfully maintains the circuits that once controlled the missing limb.",
-        "pubDate": "2025-08-21T20:20:19Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "This week in science: chocolate, daytime drowsiness and seabirds' bathroom habits",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5502833/this-week-in-science-chocolate-daytime-drowsiness-and-seabirds-bathroom-habits",
-        "description": "NPR's Hannah Chinn and Emily Kwong talk about the microbes behind great-tasting chocolate, possible reasons for daytime drowsiness, and a curious observation about the poop of seabirds.",
-        "pubDate": "2025-08-21T20:20:13Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Artificial light has essentially lengthened birds' day",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5507165/light-pollution-bird-day-hour-longer",
-        "description": "Millions of audio recordings of hundreds of bird species have revealed that artificial light is making the birds wake up earlier and go to bed later.",
-        "pubDate": "2025-08-21T18:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Filipino forces on alert after China deploys coast guard ships closer to disputed shoal - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitwFBVV95cUxOOG1xOXdSQkFBRVdIaHJZa3hFNDVvVFlDMUhDOGhpY0s4UHZlUG5MamR6Mm5EZU9SblJxbFF1Tm8xUk55TDdDSXliNU5IUGRQaHFtZkVGd20yZkgzWWFyZUFzZUs5T0hTNEF2MVh6cV9hTUxmSDhzUzYxOU5Pc2pCdk1yZE4yWUg4SV9uQWZXeFp4WE9acEhUYjE1QUpIZW50Y2gwTlpvNk9DTHlDRktiQThnVlhYRTQ?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T17:12:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "BBC Inside Science",
-        "link": "https://www.bbc.co.uk/sounds/play/m002hb9f?at_medium=RSS&at_campaign=rss",
-        "description": "The science of extraterrestrial solar panels and whether they can power our energy needs.",
-        "pubDate": "2025-08-21T16:00:00Z",
-        "source": "bbc.co.uk",
-        "image": "https://ichef.bbci.co.uk/images/ic/240x135/p0c2f9v1.jpg",
-        "bias": -1
-      },
-      {
-        "title": "New study raises questions about effectiveness of wolf hunting as a tool to help ranchers",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5507219/wolf-hunting-livestock-research-human-wildlife-conflict",
-        "description": "One of the goals of controversial wolf hunts in the Western U.S. is to help reduce the burden on ranchers, who lose livestock to wolves every year. A new study finds that those hunts have had a measurable, but small effect on livestock depredations.",
-        "pubDate": "2025-08-21T15:07:51Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "The transitions of aging: How parents and adult children can adjust",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5506233/transitions-aging-how-parents-adult-children-can-adjust",
-        "description": "As people age, they may be surprised to find that younger folks don't understand what they're going through, but adult children or caretakers can do a lot to help older people adjust to a new reality.",
-        "pubDate": "2025-08-21T10:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "How many giraffe species are in Africa? New scientific analysis quadruples the count - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxOS1QxWDN3UWN5S2ttRjdpRjlJWGptUTZWR1BGUm1ZZl9Ca2hXbWJZRFFYVURDaDZPd2wtb0tFUVBmbkYzVVlmclY5X181RDBlblNQaG5FTEVucUtkTGdzNEhzUl94M0xVRkk4X0J0YzI0X0ZEdU42Qk9pekladFczQkhUREt1SHBrMlE?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T08:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Will there be a drought where I live?",
-        "link": "https://www.bbc.com/news/articles/crk661074ejo?at_medium=RSS&at_campaign=rss",
-        "description": "We take a look at river, reservoir and groundwater levels after a particularly dry few months.",
-        "pubDate": "2025-08-20T19:10:59Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ec00/live/e8c273b0-569c-11f0-90cf-2db8f0b9be7b.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Scientists get a rare peek inside of an exploding star - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilAFBVV95cUxQblhRdUxiRlZvZGduMkhyTlNVcThrc1Z6S3pJQ3ktTUpmY001WEIzWmV4Qkx5RkFBd1lQbndaOU0xVkdxcmVfXzBONk9USEhFQ2gzWkFfV1dGOHI2OFhWV29XNnYtbnY5UlRUNTFoWFlWVS1ORUttTE5zekJKMGx5bHlySG9xRU5CMjZ0MTA0Z0IwZzZi?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T17:36:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Scientists make 'superfood' that could save honeybees",
-        "link": "https://www.bbc.com/news/articles/c776kynn771o?at_medium=RSS&at_campaign=rss",
-        "description": "We rely on honeybees to pollinate our crops and a new food could protect them from growing threats.",
-        "pubDate": "2025-08-20T15:03:02Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/7189/live/bf16e2a0-7deb-11f0-ab3e-bd52082cd0ae.jpg",
-        "bias": 0
-      },
-      {
-        "title": "German foreign minister backs Israel and Palestine two-state solution during Indonesia visit - AP News",
-        "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxQTUEwVFUyN2NUSHRjVDdzdTcyT3haMzBSMWtxaGIxTjBLcmFQQUVDRnJXSXFySGhHczFOYjV0YkVZMEtLUE9xNEhldG05TGo4cWpjSnFZTFBHcVBpX3NqMEpsdUpDOFNJMjQ3bGpnTFZ3S0IxdHVmX3NuaV9qTG1JOHZrbE9PbGZSY2ltUmpkdi1PYkgwMXBzdkstUVRoRWNFS0p4TUpZY2RwSXozYTFuanN3?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T10:46:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "UK independent space agency scrapped to cut costs",
-        "link": "https://www.bbc.com/news/articles/c4gmjm8z47jo?at_medium=RSS&at_campaign=rss",
-        "description": "Britain's space agency is set to be scrapped - a scientist fears the UK space sector could fall behind as a result",
-        "pubDate": "2025-08-20T00:35:23Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8115/live/f7ea0ff0-7d21-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Why scientists hope seabed mud could reveal Antarctic Ocean secrets",
-        "link": "https://www.bbc.com/news/articles/cm2vz9jg8jzo?at_medium=RSS&at_campaign=rss",
-        "description": "How long tubes of mud - drilled out of the Antarctic seafloor - could reveal how the frozen continent is changing.",
-        "pubDate": "2025-08-18T23:21:37Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/4be9/live/74786430-7788-11f0-907d-6ff0082c2def.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Leaves falling, berries ripe, but it's hot. Is autumn coming early?",
-        "link": "https://www.bbc.com/news/articles/c2enmn7j3zjo?at_medium=RSS&at_campaign=rss",
-        "description": "Has autumn come sooner than expected to the UK - and does it even matter if it has?",
-        "pubDate": "2025-08-16T23:12:36Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9c0b/live/28ef4640-79fa-11f0-abec-f3f54a291b20.png",
-        "bias": 0
-      },
-      {
-        "title": "Global plastic talks collapse as countries remain deeply divided",
-        "link": "https://www.bbc.com/news/articles/cvgpddpldleo?at_medium=RSS&at_campaign=rss",
-        "description": "The latest round of UN-led talks have ended in deadlock, with disputes over plastic production and recycling.",
-        "pubDate": "2025-08-15T11:57:06Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/aed6/live/6d043750-799b-11f0-a3c2-31369586f544.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Rabbits with ‘horns’ in Colorado are being called ‘Frankenstein bunnies.’ Here’s why - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxPZzRWcjctUkJSMnFzalZUOGN2ZHI3LTVjYmtyVWg3WDZCd1ZlcDEzOXZjRkROdWMtcktaSl9NN21OYjhOeDNneEN4UlU2UmROaG9lWVYwZnZjWG4zLWJzTlloSnI4Q0VERXFaYy0tQVZVSGxNUlNCUUZtTF9IYXVUeUxod3pPOHg4TG9FblVfczljM3J1MHFLQmVwaGNDSmlZUS1KWlpZcmRzdGJMU2lBbkpFazN3Snhid3c?oc=5",
-        "description": "",
-        "pubDate": "2025-08-15T07:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Hot, dry summers bring new 'firewave' risk to UK cities, scientists warn",
-        "link": "https://www.bbc.com/news/articles/c9vd79x97zlo?at_medium=RSS&at_campaign=rss",
-        "description": "Rising temperatures are increasing the chances of multiple wildfires at the same time, researchers say.",
-        "pubDate": "2025-08-14T00:04:14Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/aafe/live/849df340-78d0-11f0-8071-1788c7e8ae0e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Evacuations in Alaska after glacial melt raises fears of record flooding",
-        "link": "https://www.bbc.com/news/articles/c4gejyg8l7vo?at_medium=RSS&at_campaign=rss",
-        "description": "Meltwater is escaping from a basin that is dammed by a glacier - prompting fears of a deluge in state capital Juneau.",
-        "pubDate": "2025-08-13T12:32:13Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/bec7/live/0fad6450-786f-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Record warm seas help to bring extraordinary new species to UK waters",
-        "link": "https://www.bbc.com/news/articles/c05enyryqvmo?at_medium=RSS&at_campaign=rss",
-        "description": "The UK's seas have had their warmest first seven months of the year on average since records began.",
-        "pubDate": "2025-08-11T00:36:06Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/918c/live/9ea2ffa0-76a1-11f0-8071-1788c7e8ae0e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Jim Lovell, Apollo 13 astronaut, dies aged 97",
-        "link": "https://www.bbc.com/news/articles/cl7y8zq5xpno?at_medium=RSS&at_campaign=rss",
-        "description": "The commander of Apollo 13 famously rescued his men from near certain death in space.",
-        "pubDate": "2025-08-09T07:01:11Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ec50/live/f403b100-3f9e-11ef-b74c-bb483a802c97.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Nasa Apollo missions: Stories of the last Moon men",
-        "link": "https://www.bbc.com/news/articles/c4g9yde95yyo?at_medium=RSS&at_campaign=rss",
-        "description": "Of the 24 Nasa astronauts who travelled to the Moon in the Apollo missions of the 1960s and 1970s, just five remain.",
-        "pubDate": "2025-08-08T21:31:57Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8894/live/d1b29b80-74a3-11f0-8071-1788c7e8ae0e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Southern European butterfly spotted in UK for first time",
-        "link": "https://www.bbc.com/news/articles/cwy1wgly21zo?at_medium=RSS&at_campaign=rss",
-        "description": "Experts have tracked the Southern Small White's expansion northwards through Europe over decades.",
-        "pubDate": "2025-08-08T01:06:28Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/98d6/live/572e1300-7384-11f0-8071-1788c7e8ae0e.png",
-        "bias": 0
-      },
-      {
-        "title": "New checks to stop waste tyres being sent to furnaces",
-        "link": "https://www.bbc.com/news/articles/cj9wepemrj8o?at_medium=RSS&at_campaign=rss",
-        "description": "Campaigners warn the move will not close all the recycling loopholes being exploited by criminals.",
-        "pubDate": "2025-08-07T05:04:49Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2582/live/50da3250-736a-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Oceangate's Titan whistleblower: 'People were sold a lie'",
-        "link": "https://www.bbc.com/news/articles/cy0wpe9479wo?at_medium=RSS&at_campaign=rss",
-        "description": "A former Oceangate employee says he told US authorities about safety concerns with the sub before it imploded.",
-        "pubDate": "2025-08-06T05:35:42Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/6a63/live/d47e0240-5c12-11f0-a242-c52ffeb44368.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Nasa to put nuclear reactor on the Moon by 2030 - US media",
-        "link": "https://www.bbc.com/news/articles/cev2dylxv74o?at_medium=RSS&at_campaign=rss",
-        "description": "The reactor would provide power for humans on the Moon but there are questions about feasibility.",
-        "pubDate": "2025-08-05T11:36:24Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/7fdf/live/4bea4430-71ec-11f0-a178-03cc5fabe4bc.png",
-        "bias": 0
-      },
-      {
-        "title": "Mission begins to save snails threatened by own beauty",
-        "link": "https://www.bbc.com/news/articles/clyrv8ndzzjo?at_medium=RSS&at_campaign=rss",
-        "description": "Researchers in Cuba and the UK are working together to reveal the biological secrets of the beautiful but endangered Polymita snail.",
-        "pubDate": "2025-08-04T00:46:34Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3d67/live/8dec6500-6ed3-11f0-ad0c-035b9044855d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Russian volcano erupts for first time in more than 500 years",
-        "link": "https://www.bbc.com/news/articles/c0r7qlwg4zro?at_medium=RSS&at_campaign=rss",
-        "description": "The eruption of a volcano in Russia's Kamchatka peninsula may be linked to a massive earthquake last week, experts say.",
-        "pubDate": "2025-08-03T09:05:37Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ca33/live/e0d71e40-7059-11f0-8dbd-f3d32ebd3327.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Melting glaciers threaten to wipe out European villages - is the steep cost to protect them worth it?",
-        "link": "https://www.bbc.com/news/articles/cj4w9ggzxv4o?at_medium=RSS&at_campaign=rss",
-        "description": "Switzerland spends almost $500m a year on protective structures. Is it worth it - or, as some suggest, should people move away from the mountain villages at risk?",
-        "pubDate": "2025-08-02T23:06:56Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2ae0/live/32850770-6ecf-11f0-af20-030418be2ca5.png",
-        "bias": 0
-      },
-      {
-        "title": "'Communities' of strange, extreme life seen for first time in deep ocean",
-        "link": "https://www.bbc.com/news/articles/c3wnqe5j99do?at_medium=RSS&at_campaign=rss",
-        "description": "A Chinese-led research team captures pictures of life at depths of more than 9km in the northwest Pacific Ocean.",
-        "pubDate": "2025-07-31T00:02:31Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/05ed/live/6ef95290-6d50-11f0-8b42-cf5ae7bf0dcf.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Why did Russian mega earthquake not cause more tsunami damage?",
-        "link": "https://www.bbc.com/news/articles/c0l6pj7kjg7o?at_medium=RSS&at_campaign=rss",
-        "description": "The earthquake was one of the strongest ever recorded, but its tsunami was not as bad as feared.",
-        "pubDate": "2025-07-30T16:09:03Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/903e/live/6517c330-6d76-11f0-8dbd-f3d32ebd3327.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Why plane turbulence is becoming more frequent - and more severe",
-        "link": "https://www.bbc.com/news/articles/ckgy7jx082ro?at_medium=RSS&at_campaign=rss",
-        "description": "Flights are getting bumpier, thanks in part to climate change. But new studies are looking into innovative potential ways to turbulence-proof wings - using AI and owls",
-        "pubDate": "2025-07-29T23:00:12Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3593/live/d462d530-6c91-11f0-af20-030418be2ca5.png",
-        "bias": 0
-      },
-      {
-        "title": "New Brazil development law risks Amazon deforestation, UN expert warns",
-        "link": "https://www.bbc.com/news/articles/cy98jqr4p0xo?at_medium=RSS&at_campaign=rss",
-        "description": "A new environmental licensing law has been criticised by environmentalists as Brazil prepares for COP30.",
-        "pubDate": "2025-07-29T21:36:53Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/6ffa/live/73d3faa0-6cc3-11f0-96b5-2b05ac17417f.jpg",
-        "bias": 0
-      },
-      {
-        "title": "US to scrap landmark finding that sets limit on carbon emissions",
-        "link": "https://www.bbc.com/news/articles/c0mlzz1gy39o?at_medium=RSS&at_campaign=rss",
-        "description": "Experts warn the move will severely curb the federal government's ability to combat climate change.",
-        "pubDate": "2025-07-29T18:42:33Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d77f/live/c5b0d1d0-6c92-11f0-9a27-87bb9aa7e3da.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Thousands of river pollution tests cancelled because of staff shortages",
-        "link": "https://www.bbc.com/news/articles/cx24xy8zgp4o?at_medium=RSS&at_campaign=rss",
-        "description": "Testing programmes affected include those monitoring the impact of drought.",
-        "pubDate": "2025-07-24T03:12:14Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8c9b/live/16ba1c00-67e6-11f0-8dbd-f3d32ebd3327.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Unique 1.5m year-old ice to be melted to unlock mystery",
-        "link": "https://www.bbc.com/news/articles/c5ygwd6yj28o?at_medium=RSS&at_campaign=rss",
-        "description": "BBC News went inside -23C freezers to see the ice that could \"revolutionise\" our knowledge of climate change.",
-        "pubDate": "2025-07-18T00:18:22Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/6af0/live/8f49a040-633c-11f0-89ea-4d6f9851f623.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Kew Gardens' Palm House will close for five years for major makeover",
-        "link": "https://www.bbc.com/news/articles/cpwq08rxxklo?at_medium=RSS&at_campaign=rss",
-        "description": "The 175-year-old glass house will begin a £50m renovation in 2027.",
-        "pubDate": "2025-07-15T23:01:44Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ffce/live/eca2eaa0-61ff-11f0-b5c5-012c5796682d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "The fate of the Sycamore Gap tree has shed light on a deeper concern",
-        "link": "https://www.bbc.com/news/articles/cnvmpz5qqe5o?at_medium=RSS&at_campaign=rss",
-        "description": "The felling has prompted calls for stricter legal protections for other trees and drawn attention to wider issues",
-        "pubDate": "2025-07-15T00:04:28Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2155/live/81c28a20-6091-11f0-960d-e9f1088a89fe.png",
-        "bias": 0
-      },
-      {
-        "title": "Tiny creatures gorge, get fat, and help fight global warming",
-        "link": "https://www.bbc.com/news/articles/c628nnz3rp9o?at_medium=RSS&at_campaign=rss",
-        "description": "Scientists find out how the epic deep sea migration of a tiny animal is storing planet-warming carbon.",
-        "pubDate": "2025-07-04T23:10:52Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/fa52/live/c67072f0-58f7-11f0-960d-e9f1088a89fe.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Ancient Egyptian history may be rewritten by DNA bone test",
-        "link": "https://www.bbc.com/news/articles/c1dnnyz0z6do?at_medium=RSS&at_campaign=rss",
-        "description": "A DNA bone test on a man who lived 4,500 years ago sheds new light on the rise of Ancient Egypt.",
-        "pubDate": "2025-07-02T15:01:49Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/99f0/live/86b579b0-5683-11f0-b5c5-012c5796682d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Recent droughts are 'slow-moving global catastrophe' - UN report",
-        "link": "https://www.bbc.com/news/articles/ckg33r1xgymo?at_medium=RSS&at_campaign=rss",
-        "description": "It says drought has compounded poverty, hunger, and energy insecurity worldwide.",
-        "pubDate": "2025-07-02T12:31:51Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/4f24/live/326fee30-5728-11f0-a129-bdd7ff3be6de.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Work begins to create artificial human DNA from scratch",
-        "link": "https://www.bbc.com/news/articles/c6256wpn97ro?at_medium=RSS&at_campaign=rss",
-        "description": "Scientists start a controversial project to create the building blocks of human life, in what is thought to be a world first.",
-        "pubDate": "2025-06-26T00:09:45Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/32d1/live/2a9c9440-523e-11f0-a2ff-17a82c2e8bc4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "India sends its first astronaut into space in 41 years",
-        "link": "https://www.bbc.com/news/articles/cz09lx2gjm4o?at_medium=RSS&at_campaign=rss",
-        "description": "Group Captain Shubhanshu Shukla has become only the second Indian to travel to space.",
-        "pubDate": "2025-06-25T06:38:38Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2062/live/c9ed9850-518f-11f0-b974-07211ef08f11.jpg",
-        "bias": 0
-      }
-    ],
-    "Business": [
-      {
-        "title": "Canada's retaliatory tariffs have left the U.S. wine industry reeling",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5502688/canadas-retaliatory-tariffs-have-left-the-u-s-wine-industry-reeling",
-        "description": "NPR's Ayesha Rascoe talks to Joan Kautz of Ironstone Vineyards, a winery in California, about the impact of Canadian tariffs on the U.S. alcohol industry.",
-        "pubDate": "2025-08-24T12:51:55Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Call to end airport drop-off fees for blue badge holders",
-        "link": "https://www.bbc.com/news/articles/cn5e1z6gz5yo?at_medium=RSS&at_campaign=rss",
-        "description": "UK airports' charging policies are inconsistent and unfair, says Disabled Motoring UK.",
-        "pubDate": "2025-08-24T00:54:01Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8984/live/d166f4b0-7952-11f0-aaf6-d3dc859efb2f.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Trump administration halts work on an almost-finished wind farm",
-        "link": "https://www.npr.org/2025/08/23/nx-s1-5513919/trump-stops-offshore-wind-renewable-energy",
-        "description": "The Revolution Wind farm was slated to start sending power to homes and businesses in Rhode Island and Connecticut starting next year.",
-        "pubDate": "2025-08-23T15:38:19Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "A timeline of the Menendez brothers’ double-murder case - AP News",
-        "link": "https://news.google.com/rss/articles/CBMivAFBVV95cUxNWVZhWTFIZ0FzRF90cGJMc09nRzNUck9uNXJ4djNfVEhQUnRQV255VW9iUVBSVnFraHJEVTIzdWRaWGU1ekFuckF6RWJiazRPb3ZzNlNtQmhQZktLdFU5c3VkWC1MSlhDY1NpUUNrZkJId1lPNk1sQVdvU0FEOEllei1BWmI4dXN1UVVuWkxISGE4SWF1ZnpYRTlzTVpfQnFaUzllTDJXTldEMEI0bW14T01BOWJjS0FOdVl4Zg?oc=5",
-        "description": "",
-        "pubDate": "2025-08-23T03:28:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "White House announces chipmaker Intel to give US government 10% stake",
-        "link": "https://www.bbc.com/news/articles/cvg3zpdl3xdo?at_medium=RSS&at_campaign=rss",
-        "description": "President Trump earlier said the company's CEO agreed to the deal in a recent meeting at the White House.",
-        "pubDate": "2025-08-22T22:27:03Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/cfaa/live/a73e8870-7fa5-11f0-9cc4-df69a0381099.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Canada to drop some of its retaliatory tariffs on the US",
-        "link": "https://www.bbc.com/news/articles/c5yk9dqlvygo?at_medium=RSS&at_campaign=rss",
-        "description": "The move comes after the two countries blew past a self-imposed deadline to reach a trade agreement.",
-        "pubDate": "2025-08-22T20:11:17Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b9d2/live/17fc37d0-7f72-11f0-8844-df46f3a0217b.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Travellers warned of bank holiday disruption",
-        "link": "https://www.bbc.com/news/articles/c1kzrxwjnryo?at_medium=RSS&at_campaign=rss",
-        "description": "A rail strike and works are expected this weekend as millions begin their bank holiday getaways.",
-        "pubDate": "2025-08-22T17:32:43Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/11b7/live/411c9c80-7f0a-11f0-8e6f-0365c408e6a9.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Brewdog co-founder leaves craft beer giant",
-        "link": "https://www.bbc.com/news/articles/cg50p64rev3o?at_medium=RSS&at_campaign=rss",
-        "description": "Martin Dickie, who founded the Ellon-based firm with James Watt in 2007, announced his decision in an email to staff.",
-        "pubDate": "2025-08-22T17:26:59Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3239/live/af484ec0-7f78-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Fed chair Powell boosts expectation of US rate cut",
-        "link": "https://www.bbc.com/news/articles/c5ylwyx43x4o?at_medium=RSS&at_campaign=rss",
-        "description": "Jerome Powell appeared to back a cut to borrowing rates and played down long term inflation risks in his annual speech at Jackson Hole.",
-        "pubDate": "2025-08-22T16:33:16Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/c3aa/live/56295a90-7f74-11f0-8844-df46f3a0217b.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Fed Chair Jerome Powell signals possible rate cut, sending stocks sharply higher",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5509941/jerome-powell-federal-reserve-interest-rates-jackson-hole",
-        "description": "Federal Reserve chairman Jerome Powell signaled a possible interest rate cut in the months to come, sending stocks sharply higher.",
-        "pubDate": "2025-08-22T16:05:33Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Royal Mail and DHL halt some US deliveries over tariffs",
-        "link": "https://www.bbc.com/news/articles/cx2p17xypgko?at_medium=RSS&at_campaign=rss",
-        "description": "Services including Royal Mail and  DHL say they are suspending deliveries until they have proper systems in place.",
-        "pubDate": "2025-08-22T15:38:48Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/f5ce/live/d567fd50-7f62-11f0-9b45-d97edf6817de.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Revolution Beauty to 'reset' after sale falls through",
-        "link": "https://www.bbc.com/news/articles/c36j2nxg202o?at_medium=RSS&at_campaign=rss",
-        "description": "Co-founders Adam Minto and Tom Allsworth will return to the troubled brand after plummeting sales.",
-        "pubDate": "2025-08-22T14:47:57Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/184a/live/1ec72770-7f43-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Assaults on public-facing workers should be specific offence, bosses say",
-        "link": "https://www.bbc.com/news/articles/c79ljgx0el8o?at_medium=RSS&at_campaign=rss",
-        "description": "The Institute of Customer Service says many are considering leaving their jobs as a result of abuse.",
-        "pubDate": "2025-08-22T14:31:05Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9923/live/08393d70-7f22-11f0-a851-ef9f43f308ac.jpg",
-        "bias": 0
-      },
-      {
-        "title": "The shop making people laugh for nearly 100 years",
-        "link": "https://www.bbc.com/news/videos/czjmn21r194o?at_medium=RSS&at_campaign=rss",
-        "description": "Hull's iconic Dinsdale's joke shop has remained pretty much untouched for almost a century.",
-        "pubDate": "2025-08-22T10:10:22Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9588/live/3ac7ebb0-736f-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "She's cared for America's elderly for decades. Trump wants her gone by Sept. 8",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5502439/trump-immigration-tps-health-care",
-        "description": "The Trump administration has moved to end temporary protected status for immigrants from Honduras and other countries. Among them are health care workers tending to older and disabled people.",
-        "pubDate": "2025-08-22T09:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Home sales are ticking up — and more are coming to market",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5510058/housing-market-mortgage-rates-homebuilding",
-        "description": "High mortgage rates cooled home sales over the last few years. But data released this week shows signs that things may be thawing a bit.",
-        "pubDate": "2025-08-22T09:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "What happens when people stop trusting their government's economic data?",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5499343/what-happens-when-people-stop-trusting-their-governments-economic-data",
-        "description": "What happens when people stop trusting their government's economic data? Planet Money reports on what happened in Greece.",
-        "pubDate": "2025-08-22T08:46:55Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "'I work full-time but can't afford school uniform'",
-        "link": "https://www.bbc.com/news/articles/cj4w0l5krvxo?at_medium=RSS&at_campaign=rss",
-        "description": "Parents using a free clothing bank say they are already making cut-backs to pay for schoolwear.",
-        "pubDate": "2025-08-22T08:30:12Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/418d/live/65d22230-7f40-11f0-ace8-c7fe3706c172.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Trump backs down from 250% EU pharma tariff in deal",
-        "link": "https://www.bbc.com/news/articles/ckgjwk8gze7o?at_medium=RSS&at_campaign=rss",
-        "description": "The US and EU have released details of the new trade deal reducing tariffs between the two partners.",
-        "pubDate": "2025-08-22T07:23:04Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/c8a5/live/9ad1f700-7e8f-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "WH Smith shares tumble 42% after accounting blunder",
-        "link": "https://www.bbc.com/news/articles/c3v363zr6kdo?at_medium=RSS&at_campaign=rss",
-        "description": "The retailer has drafted in auditors to review the issue and slashed its profit guidance.",
-        "pubDate": "2025-08-22T05:56:16Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/452a/live/f8d0d1b0-7e7a-11f0-96e5-5b061b987076.jpg",
-        "bias": 0
-      },
-      {
-        "title": "'Significant disruption' as CrossCountry trains cut",
-        "link": "https://www.bbc.com/news/articles/cwy5vplw54jo?at_medium=RSS&at_campaign=rss",
-        "description": "RMT members will walk out on Saturday and Monday, but Sunday trains could also be cancelled.",
-        "pubDate": "2025-08-22T05:10:50Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/aec3/live/da2d5d60-7e8d-11f0-af3b-efde9c4d0da6.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Brazil's police accuse Bolsonaro of receiving $5 million over 1 year, suspect money laundering - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxNQWVqeEV4TXZCOTlwMjcwQkxxR3paS0xBMkljT2tFRl9CT3hTN2drSjVGSHZpMUhNa2V4WVRoMkdvLWpPNGYtUkM2TXI0QmxJaEM4dTNlY0ppUjF6ZUVGeWR4bHF3OU9ySU5iX2tDVXVwYmRHeDYzZ25vU0dud3lVcTFkMnJUMDJ6emN0OHB4V2VVOTZtTnpGOV92V1ZuNzNzamVLOVdQdHZxZFFPV1E?oc=5",
-        "description": "",
-        "pubDate": "2025-08-22T00:22:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Iowa Democrats consider bringing back lead off caucuses, even if it means going 'rogue' in 2028 - AP News",
-        "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxNdlc5NzJla2xDSEtRbFFaY0l1Z1kwQXlHcC16dEN3WUI2bkE5UV9xSFJoYVhEbDF2aDhwYkxJV3E0NDNGZkNNTTZjZnpBcGRuWEthNndtN3k3akNqTTlfaThEYjdDSDJ6U0NfTExKZnpJdG5WOU11VXlNaVVtWHdWanluMWlnTnpEZUF2blJLRXZ4MnNxc0huR21YOA?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T19:02:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Volunteers suspend Ruby Whitehorn indefinitely nearly 2 weeks after arrest - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiowFBVV95cUxNRkVFTFA0YzdEOF80cWlKRjJpOVZLSmpzSkxDSnFqWVpYQVo3cjhRZWU4YlNVQnpFb01wNXRHb2hTbmNVaXllbldla1BLM3N1RkNfVVJmaXBDUHVoOExtRDVrWkRWU1VBaDdBdDZHWWhtY2oySHh4RkZRSVVYMExkdTk5anl4TVNFcjV2elpCTURXdUdKTGJlT0ZzcGdzTWZNWHdB?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T17:15:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Students face new cellphone restrictions in 17 states as school year begins - AP News",
-        "link": "https://news.google.com/rss/articles/CBMipgFBVV95cUxOYkhpaFpxRGdnOFRFdk5YTFJlMVhCOUdIYm56NHpjcGJ1Z1dYWmhhUVdXZVEwZGlQVGhHVVFQTFl1ZElPbHkxc1lDb19DZGpmVE44RTIzZ2NsYktmZW1iOF95VmxRa2d2R1Z6LWMzSjZoSFpXZlJRaWRNNnBIc0FWcGtDTWt3UmJJeVl5YUhUOEt2MXpacmhlZjJjekZCU0ZWeVJXZmFn?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T15:34:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Tesco meal deal price rises by 25p",
-        "link": "https://www.bbc.com/news/articles/clyr7renp51o?at_medium=RSS&at_campaign=rss",
-        "description": "The move by the UK's largest supermarket is the latest example of rising food prices.",
-        "pubDate": "2025-08-21T14:31:23Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b72f/live/73d27d50-7e85-11f0-ab3e-bd52082cd0ae.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Tube staff to strike over pay and work conditions",
-        "link": "https://www.bbc.com/news/articles/cn728er5p1mo?at_medium=RSS&at_campaign=rss",
-        "description": "RMT union members will strike from Friday 5 September for seven days.",
-        "pubDate": "2025-08-21T14:23:47Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d4f1/live/a8dbc7f0-aca2-11ef-80a8-1d72d6de619d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Average five-year mortgage at lowest level since 2023",
-        "link": "https://www.bbc.com/news/articles/cdd3qm7ly8ro?at_medium=RSS&at_campaign=rss",
-        "description": "The average five-year fixed rate is now 4.99%, falling below 5% for the first time since 2023.",
-        "pubDate": "2025-08-21T14:22:51Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/cd35/live/974444c0-7e81-11f0-9e05-3dbec5559644.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Foundation seeks charity partners for new projects",
-        "link": "https://www.bbc.com/news/articles/cly7gd0wgq3o?at_medium=RSS&at_campaign=rss",
-        "description": "Guernsey Community Foundation invites charities to collaborate on tackling living costs and housing.",
-        "pubDate": "2025-08-21T05:14:36Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/0fd2/live/1d954730-7dcf-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "County's 'secret' festival marks 25th anniversary",
-        "link": "https://www.bbc.com/news/articles/cr5r793lvggo?at_medium=RSS&at_campaign=rss",
-        "description": "The four-day Shambala Festival is set to welcome about 15,000 people to Northamptonshire.",
-        "pubDate": "2025-08-21T05:07:31Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/a228/live/8da00340-07af-11ef-b289-a77873562b61.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Delta and United sued for selling 'window seats' without windows",
-        "link": "https://www.bbc.com/news/articles/c754k7d0z51o?at_medium=RSS&at_campaign=rss",
-        "description": "Delta and United are being sued over allegedly charging extra for seats next to a blank walls.",
-        "pubDate": "2025-08-21T02:57:04Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2f29/live/9b2932a0-7e2a-11f0-bebe-e53cb25f8f71.jpg",
-        "bias": 0
-      },
-      {
-        "title": "A look at those Trump has targeted in tactic of revoking security clearances - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxNYWxwR1VpellpNkVOa2UzYXFJMU0xVWlzcmhzQVZoMEw4ZmZFeC1TbGw0TUZVNDZhZjEwN3NUOGl1LS00dE9oQmYtVkVoekttSzA5cXczWUpQMnEtTm81aFRHYkVMSXk1MVYzSzFlUC0tNE1tRnQ3ZmlYZ09KQVBzOUcxOXdkS3ZTQ1k2THU0Z2oyMHNlakFN?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T01:02:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Denmark ending letter deliveries is a sign of the digital times",
-        "link": "https://www.bbc.com/news/articles/c3v37plv2edo?at_medium=RSS&at_campaign=rss",
-        "description": "PostNord blames sharply falling demand - will other post firms around the world follow suit?",
-        "pubDate": "2025-08-20T23:04:51Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9533/live/368517b0-7ccc-11f0-82af-13bf485dd06a.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Federal Reserve official says she won’t be ‘bullied’ by Trump into resigning - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxOMUMzQmdkcEhEbzFVbzFxMEUyZk5zcWoyek4zMmJVM3ZMNnAzcjhuNWRtZW5vcFp3YWNKSldYVk53M1UwUDlsaTRNbWlhRmRKSVNsSlN6UmMtTGRsOE85NTJzdjROaHJqSENpYkIweDMxcXRlN2tzTTliQmRMZzVGNk1keHBKazNOTzlXMU03T00?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T22:19:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Pirates are going to call up Bubba Chandler, baseball’s top pitching prospect - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiggFBVV95cUxQWk0xVW9teEJvVmZ1TmQ2dkVDOUg2UkdEV0NqTmlJWlZNbm41N3FsYUhJTkM5LVFsbTZIY1NrMzl3VmQxMHhLUV9QUmFGY052ckQ2OU5Hblo1azZETHhYZ1Fab25EaG9FTzJ3YWdNTklaaU1zUy1sUDBCVXJHRk1NeDF3?oc=5",
-        "description": "",
-        "pubDate": "2025-08-20T20:41:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Sentencing for man who dodged 113 train tickets delayed",
-        "link": "https://www.bbc.com/news/articles/cwy38zmvk04o?at_medium=RSS&at_campaign=rss",
-        "description": "Charles Brohiri was granted bail despite clocking up £30,000 in penalty fares.",
-        "pubDate": "2025-08-20T17:02:28Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3b1a/live/1df20900-7dd6-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Government prepares to take over UK's third-largest steelworks",
-        "link": "https://www.bbc.com/news/articles/cj0yd0829m4o?at_medium=RSS&at_campaign=rss",
-        "description": "Managers have been lined up to take control in a bid to protect 1,500 jobs at the Yorkshire plant.",
-        "pubDate": "2025-08-20T16:36:07Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/66db/live/1b193490-7dd8-11f0-ab3e-bd52082cd0ae.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Foodbank manager surprised at high demand for service",
-        "link": "https://www.bbc.com/news/articles/cjw6z53wl1lo?at_medium=RSS&at_campaign=rss",
-        "description": "The new manager Gloucester Foodbank said she was unaware of how many people still need help.",
-        "pubDate": "2025-08-20T14:38:32Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/28c7/live/46f8ff30-7da3-11f0-8701-ef823735961d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Why are food prices still rising by so much?",
-        "link": "https://www.bbc.com/news/articles/cyvn9z3y78lo?at_medium=RSS&at_campaign=rss",
-        "description": "Food and drink prices have risen by 4.9% over the last year, according to ONS inflation data.",
-        "pubDate": "2025-08-20T14:00:07Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2ef8/live/2381b250-7dcf-11f0-88a2-b9725373e32e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Business Daily",
-        "link": "https://www.bbc.co.uk/sounds/play/w3ct6s2g?at_medium=RSS&at_campaign=rss",
-        "description": "Thousands of firms have the certification, but some think the rules aren't strict enough",
-        "pubDate": "2025-08-14T08:03:00Z",
-        "source": "bbc.co.uk",
-        "image": "https://ichef.bbci.co.uk/images/ic/240x135/p0lw993j.jpg",
-        "bias": -1
-      },
-      {
-        "title": "'One video about a dress made me £6,000'",
-        "link": "https://www.bbc.com/news/videos/c7vl1402lmdo?at_medium=RSS&at_campaign=rss",
-        "description": "Single mum Roxanne Freeman has paid off her debt with her earnings as a TikTok content creator.",
-        "pubDate": "2025-08-13T15:42:57Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/aad2/live/4e8ca030-7849-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "The UK car industry is at a tipping point - can it be saved?",
-        "link": "https://www.bbc.com/news/articles/c23p028p200o?at_medium=RSS&at_campaign=rss",
-        "description": "Tariffs, Brexit, pandemic havoc... All of this caused short-term disruption - but the impact concealed a deeper problem for the UK automotive industry",
-        "pubDate": "2025-08-12T23:00:58Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/c892/live/457e4ce0-736d-11f0-8071-1788c7e8ae0e.png",
-        "bias": 0
-      },
-      {
-        "title": "Inside Australia's billion-dollar bid to take on China's rare earth dominance",
-        "link": "https://www.bbc.com/news/articles/cgm2z91mvlvo?at_medium=RSS&at_campaign=rss",
-        "description": "Recent moves by Beijing have got businesses worried - and Australia is looking to offer an alternative.",
-        "pubDate": "2025-08-12T22:05:03Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/a471/live/fc000d40-7756-11f0-89ee-73563f6604dd.jpg",
-        "bias": 0
-      },
-      {
-        "title": "China's unemployed young adults who are pretending to have jobs",
-        "link": "https://www.bbc.com/news/articles/cdd3ep76g3go?at_medium=RSS&at_campaign=rss",
-        "description": "With Chinese youth unemployment high, individuals are paying to go into offices and pretend to work.",
-        "pubDate": "2025-08-11T01:50:13Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9aeb/live/b97674d0-744c-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Why firms are merging HR and IT departments",
-        "link": "https://www.bbc.com/news/articles/cy0w8gvq84xo?at_medium=RSS&at_campaign=rss",
-        "description": "The emergence of AI is spurring some firms to make their HR and IT departments work closer together.",
-        "pubDate": "2025-08-07T23:13:47Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/50c3/live/4494e6a0-55c6-11f0-960d-e9f1088a89fe.jpg",
-        "bias": 0
-      },
-      {
-        "title": "How Europe is vying for rare earth independence from China",
-        "link": "https://www.bbc.com/news/articles/cm2zp6m4gy7o?at_medium=RSS&at_campaign=rss",
-        "description": "The EU is aiming to increase its own production of rare earth metals, led by a facility in France.",
-        "pubDate": "2025-08-06T23:02:31Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/04fd/live/a1e5b770-60bc-11f0-b5c5-012c5796682d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Will new greener brake pads be more expensive?",
-        "link": "https://www.bbc.com/news/articles/cp3l4qz1l9qo?at_medium=RSS&at_campaign=rss",
-        "description": "Automotive industry will have to change techniques and materials as new EU rules come into force in 2026",
-        "pubDate": "2025-08-04T23:06:39Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9029/live/75793c50-533f-11f0-8485-7bd50fa63665.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Trump's global tariffs 'victory' may well come at a high price",
-        "link": "https://www.bbc.com/news/articles/c0l6g13rlwko?at_medium=RSS&at_campaign=rss",
-        "description": "The US president considers it a win - but if this all triggers a foundational realignment, the results may not break in his favour",
-        "pubDate": "2025-07-31T23:01:04Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d47d/live/c1b3a180-6e1c-11f0-89ea-4d6f9851f623.png",
-        "bias": 0
-      },
-      {
-        "title": "Judge bars ICE from immediately taking Abrego Garcia into custody if he’s released from jail - AP News",
-        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxPbmkzbmtRRWxabmRadlRFTlVVQ2JZWnFsUzdPZnpUemVMVk5ZTDMtQXQ1bjRndlVOVElzaHktUkVZMzFqemZSaFEtOG9UN2Myamd0d0Z0V1hjTEFDTWc5bFlWeFRUNGFCWUVFZzdoWkNqM19KMGhyN3R6LVNUVW9BWUF6dkVZQWV0OFVCdU1iMDFNSWVieml5NXFwVWw?oc=5",
-        "description": "",
-        "pubDate": "2025-07-23T07:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "An Omaha food plant owner says he followed the rules for hiring immigrants. It was raided anyway. - AP News",
-        "link": "https://news.google.com/rss/articles/CBMingFBVV95cUxQaEVFZ0J1eFE4YW4xN3pMMkJ2ZGUtcFdQazVXVjJac3lQOFN6MzFFbl9ZV2FzOGdPSmU1eFdxM3NKV2JXMVd2UzR1WFRhWjQ3anh0NHlONFRTNFBKS0JKSlRycFRZLXJZUWl2NzUyYnoyNTM1dG5BeThacjNKMm5RdWVoSFN0QmdTc0Z1UHJzeEhKOXRFY0pkM2RCUGxtQQ?oc=5",
-        "description": "",
-        "pubDate": "2025-06-11T07:00:00Z",
+        "pubDate": "2025-08-22T12:22:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       }
     ],
-    "Culture": [
+    "Events": [
       {
-        "title": "Fans across the country raise their voices at 'KPop Demon Hunters' singalongs",
-        "link": "https://www.npr.org/2025/08/24/nx-s1-5509691/kpop-demon-hunters-singalong-huntrix-saja-boys-netflix",
-        "description": "Netflix's wildly popular movie about a fictitious all-girl rock band is hitting nearly 1,800 movie theaters around the country this weekend as a singalong version.",
-        "pubDate": "2025-08-24T09:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Bands boycott music festival after group's set 'cut off'",
-        "link": "https://www.bbc.com/news/articles/c1jnyrk07ndo?at_medium=RSS&at_campaign=rss",
-        "description": "The Last Dinner Party, Cliffords and The Academic refuse to perform at Victorious Festival.",
-        "pubDate": "2025-08-24T08:20:42Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b807/live/f8b7bfe0-80f5-11f0-83cc-c5da98c419b8.png",
-        "bias": 0
-      },
-      {
-        "title": "Pierce Brosnan felt 'huge responsibility' towards Thursday Murder Club fans",
-        "link": "https://www.bbc.com/news/articles/cn47gkpywk2o?at_medium=RSS&at_campaign=rss",
-        "description": "Dame Helen Mirren, Celia Imrie and Sir Ben Kingsley round out a quartet that unites to investigate murder.",
-        "pubDate": "2025-08-24T04:02:18Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/21cc/live/c4ca22e0-7dcb-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Were masterpieces worth £100m really found under a pensioner's bed?",
-        "link": "https://www.bbc.com/news/articles/cz932w11qwdo?at_medium=RSS&at_campaign=rss",
-        "description": "Three works attributed to Malevich are on show in Bucharest but an art scholar says the story behind them is problematic.",
-        "pubDate": "2025-08-24T00:43:05Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/66b4/live/8aa63e50-7f74-11f0-ab3e-bd52082cd0ae.jpg",
-        "bias": 0
-      },
-      {
-        "title": "First trans comedian to win Edinburgh comedy award",
-        "link": "https://www.bbc.com/news/articles/cvgvz090195o?at_medium=RSS&at_campaign=rss",
-        "description": "Sam Nicoresti took the esteemed award for their show Baby Doomer, while Ayoade Bamgboye won the award for best newcomer.",
-        "pubDate": "2025-08-23T13:57:13Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/817c/live/f82509c0-8019-11f0-82db-8bc54f381798.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Actress Sue Johnston to return to Brookside",
-        "link": "https://www.bbc.com/news/articles/cr74pv25n88o?at_medium=RSS&at_campaign=rss",
-        "description": "The acclaimed actress is set to return to Brookside Close for a one-of special episode this year.",
-        "pubDate": "2025-08-23T06:02:00Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ec80/live/0a13d190-7f69-11f0-aed6-a9b9ead85975.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Fans loved her new album. The thing was, she hadn't released one",
-        "link": "https://www.bbc.com/news/articles/clydz8d03dvo?at_medium=RSS&at_campaign=rss",
-        "description": "Artists on the mystery of being targeted by fraudsters releasing \"AI slop\" songs in their name.",
-        "pubDate": "2025-08-22T23:12:40Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/94c2/live/0b7bf260-7dcf-11f0-88a2-b9725373e32e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Anime fans hate live-action remakes - here's why studios still keep making them",
-        "link": "https://www.bbc.com/news/articles/cy8jl9wvdlno?at_medium=RSS&at_campaign=rss",
-        "description": "Beloved anime series Solo Leveling is the latest of the genre to be turned into a live-action remake by Netflix.",
-        "pubDate": "2025-08-22T22:03:38Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/b9e2/live/f8e1eaa0-692f-11f0-89f9-2557e37258a0.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Chappell Roan slays Reading Festival with fairytale-themed set",
-        "link": "https://www.bbc.com/news/articles/cr74p245zdlo?at_medium=RSS&at_campaign=rss",
-        "description": "The US star took to the stage on Friday night, and was almost drowned out by her devoted fans.",
-        "pubDate": "2025-08-22T21:26:47Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8ff6/live/34c96e40-7f9b-11f0-84a2-0722ea84f1f9.png",
-        "bias": 0
-      },
-      {
-        "title": "She travelled eight hours by bus for violin lessons. Now she's playing Wembley with Coldplay",
-        "link": "https://www.bbc.com/news/articles/c93de1y9nl5o?at_medium=RSS&at_campaign=rss",
-        "description": "Musician Pathrycia Mendonça will play with the band as part of Venezuela's Simón Bolívar Symphony Orchestra.",
-        "pubDate": "2025-08-22T15:59:13Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/44f1/live/e05f8b90-7f73-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "'Weapons' exposes the dark underbelly of American suburbia",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5507122/weapons-review",
-        "description": "Small-town life is upended when 17 schoolchildren suddenly vanish without explanation in the middle of the night.",
-        "pubDate": "2025-08-22T15:49:17Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Remembering British actor Terence Stamp",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5511161/remembering-british-actor-terence-stamp",
-        "description": "Stamp, who died Aug. 17, was part of a wave of working-class British actors who came up in the 1960s. His films include",
-        "pubDate": "2025-08-22T14:36:40Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Daniel Dae Kim is still waiting for his rom-com moment. In the meantime, there’s ‘Butterfly’ - AP News",
-        "link": "https://news.google.com/rss/articles/CBMimgFBVV95cUxPWXVPWXFMaXJWTy1VS2lCZnVIcm5KNXJjOWdfa3Y4MUNtYXhuaHlmYzVmX2xycjNfbDl0UDdYakVVX25xVm1vcnNyRVAxazFGaC01U0hoWTVYX3J5SDJRby1IaFYwRUd5RXcxeU1admU2MjZoX0VjdWt5aDZFbTNmV1Fmc3M1UmY5eUtmNGlyRTV0dlpMTWhicUtB?oc=5",
+        "title": "Hocking County fire chief found not guilty of impersonating police officer - WSYX",
+        "link": "https://news.google.com/rss/articles/CBMi1wFBVV95cUxOZUFMdHlVeWpUTHd1b2IwNlBVZ20wVENCc1VSZUNDTFFwa0Ffek56ZEJablRpb1VwVDg2M3EtWFczN0E1MzgzdEk0VWR1ZHFHeXVGbF84MEFjU0NXcVlFM0ZTcVdLZmZyeVN6Y2pLX2NmZlMtZWJHWXRwU3IxN1UwVkRBTGtXd1VmSzNNN1MzT3pmQkJSNG11YlJfT0tlRXpNRUlsSHJGdDBnTXVGSmhaT21wVDg0bWdZUlQwVDF5NGpScWZ5MnJhYXFVdTRTR2xBNVlWakx4MA?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T14:20:00Z",
+        "pubDate": "2025-08-24T21:01:20Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Noel Clarke loses libel case against the Guardian",
-        "link": "https://www.bbc.com/news/articles/cwy33g0lelno?at_medium=RSS&at_campaign=rss",
-        "description": "The award-winning actor sued the newspaper's publisher for printing allegations of sexual misconduct.",
-        "pubDate": "2025-08-22T13:53:42Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/29a1/live/f221eb10-7691-11f0-9b97-07a092acff81.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Spinal Tap 2 spotted being filmed at Stonehenge",
-        "link": "https://www.bbc.com/news/articles/c7765lyenlvo?at_medium=RSS&at_campaign=rss",
-        "description": "The ancient monument has been closing early this week to allow filming of the sequel to take place.",
-        "pubDate": "2025-08-22T13:00:13Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/a1a8/live/1371cd80-7f4d-11f0-ace8-c7fe3706c172.jpg",
-        "bias": 0
-      },
-      {
-        "title": "A box office record-setter you've never heard of and more in theaters this weekend",
-        "link": "https://www.npr.org/2025/08/22/nx-s1-5508092/ne-zha-2-lurker-honey-dont-in-theaters-this-weekend",
+        "title": "Stoka’s 90th Minute Free Kick Strike Lifts Marquette Over North Florida Sunday - Marquette University Athletics",
+        "link": "https://news.google.com/rss/articles/CBMixwFBVV95cUxPQU1RRXBNRDRFZDZsM0x0WUotamFJVXIyMmtES1ZMeHJPbjF0Nm9xZG1tUHVHd2xGcWhJVXNPa0NTbUxGeEw3U1RJQzRkSHRkeFpLOHZ6R05Idkh2amlGcFRaZkRXOXBmYkZqSWYwbm9jTU04NC12ZEJRM2k4UWJESzJvZXN0ZlhyMUkydXJwSFB3SXNTb3NzZFRyQUhabmdYSm9BN2pTbmRnMEN5b25OaTZmZWRYcnJOUUlNOTBuR2Q3akczaEg4?oc=5",
         "description": "",
-        "pubDate": "2025-08-22T10:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Karen Gillan joins the cast of Highlander reboot",
-        "link": "https://www.bbc.com/news/articles/cq87gn3q0yvo?at_medium=RSS&at_campaign=rss",
-        "description": "The Scottish actress will star alongside former Superman actor Henry Cavill in a reboot of the classic 80s movie.",
-        "pubDate": "2025-08-22T09:45:41Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/44b9/live/3962a680-7ecc-11f0-b30f-b9c0098f6de3.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Mastodon guitarist Hinds dies in motorcycle crash",
-        "link": "https://www.bbc.com/news/articles/cp8968vdlp0o?at_medium=RSS&at_campaign=rss",
-        "description": "The 51-year-old, who left the band earlier this year, died in a collision in Atlanta, US.",
-        "pubDate": "2025-08-22T08:20:26Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3417/live/a9e5c1d0-7f30-11f0-b7ed-0b17109072b5.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Lil Nas X arrested and taken to hospital after wandering LA streets in underwear",
-        "link": "https://www.bbc.com/news/articles/cgm2ep3eym7o?at_medium=RSS&at_campaign=rss",
-        "description": "The LAPD allege the singer \"charged\" at them and was placed under arrest on suspicion of battery.",
-        "pubDate": "2025-08-22T06:16:02Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3af5/live/3d5ca7c0-7edd-11f0-9f8a-81f8e371e1d1.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Billy Connolly says Elton John inspired new artwork",
-        "link": "https://www.bbc.com/news/articles/c7vlq1v2v9ro?at_medium=RSS&at_campaign=rss",
-        "description": "Sir Billy has released four new artworks recalling some of the fondest memories from his life.",
-        "pubDate": "2025-08-22T05:17:29Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/3c33/live/c5a07c10-7e83-11f0-ab3e-bd52082cd0ae.png",
-        "bias": 0
-      },
-      {
-        "title": "Will that sparked Shakespeare family row found",
-        "link": "https://www.bbc.com/news/articles/c987kjg04n5o?at_medium=RSS&at_campaign=rss",
-        "description": "The row was over William Shakespeare's grand Stratford-upon-Avon home in Warwickshire.",
-        "pubDate": "2025-08-22T05:02:13Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/63ba/live/dad7f600-7f21-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "BBC confirms Celebrity Traitors will air in October",
-        "link": "https://www.bbc.com/news/articles/c8ry41v6mllo?at_medium=RSS&at_campaign=rss",
-        "description": "About 19 famous faces will gather in the Scottish Highlands for the chance to win up to £100,000.",
-        "pubDate": "2025-08-21T18:41:08Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/5054/live/9e293bb0-7eb8-11f0-a5e2-236e16f99597.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Tyla learns how to prep for Notting Hill Carnival",
-        "link": "https://www.bbc.com/news/videos/cz93qky9qlqo?at_medium=RSS&at_campaign=rss",
-        "description": "Radio 1Xtra presenter Nadia Jae shares her top tips for Notting Hill Carnival with singer Tyla.",
-        "pubDate": "2025-08-21T13:43:40Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8ca7/live/12162360-7d03-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Pitt is hoping a little continuity can go a long way after second-half collapse last season - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxOaThIYUkyejZMT05xZFZuT3VHVmk1UDlzX0VvRmhMbC16QTJjT2RBQ2ZxZWIxOFJIRHBfd0RNUXFoYXc4Y3Zqb0w2MGtPbmZXUlJ6d21neUt0cmtxRzctODBQMHRIWnpkUG1haVpaSTJ6T1FSbXdpY2JwSHByQzlVLUhBeG9rQlJ4?oc=5",
-        "description": "",
-        "pubDate": "2025-08-21T10:10:00Z",
+        "pubDate": "2025-08-24T21:00:53Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "In 'Lurker' a social striver squirms his way into a star's inner circle",
-        "link": "https://www.npr.org/2025/08/21/nx-s1-5503422/lurker-movie-review",
-        "description": "This new film about a fan who gets close with an up-and-coming pop star lingers on the ways a relationship that might seem parasitic is closer to symbiotic.",
-        "pubDate": "2025-08-21T10:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "‘Boots on the Ground’ viral dance highlights Black trail ride culture - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiwwFBVV95cUxNZUdaaFhMMXVoNnpJdjR0bl82U083amcyNENTcU1qZlhtNElRcUtnYVluQ0czdU9ndTUxelE4TmtmVHBIYWNudFhvVGdhZ1ZLdEZ1bHlRcm9QTkNNLWtxbG1VNUJpQktteTJ3RFdLbmtqVk01MEhQdkpWbER6akNYakVIdWU5M0h5WXVMcUxkR2JUZnllQm4xMm14RFMwMnkyU2I1OFIyV1pjbk9tbVFfdF9peEd2NnpJR0tOckRUdm1Wc2c?oc=5",
+        "title": "Silo fire in Buchanan takes hours to extingush - WLUK",
+        "link": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxPanFGSHFxSTZuYVU1cm9hM0k4MU1QNmZwbVNoLTN3cm1zRDUxMm1pR25BZ21MbnVHQXRMZERwZUllUE1DUU9XeHFoUG5aZW13TGJTRV9EVmR2dy1uamhrTnd4bDBKcXBrVEFNaE5wWTJUZVNONi1QcDF3dW9GeGJIc0xzbXh4eVNo?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T09:45:00Z",
+        "pubDate": "2025-08-24T21:00:27Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Trump says no to US troops in Ukraine - AP News",
-        "link": "https://news.google.com/rss/articles/CBMia0FVX3lxTFBnd19OMnVqVk02Z2tGYXNpZTBiTDh1YTN1dnZFaGxheHBVMjc5VzJFRnNMSmFaWUNjWTRsQklHM21oOGY2eXRTTDJzcG1uNWFHQVBvMjhnRlQ2Mi1JY3lIaVlKQi1xakVNeXlj?oc=5",
+        "title": "American Red Cross to provide financial aid to some Wisconsin flood victims - WISN",
+        "link": "https://news.google.com/rss/articles/CBMiswFBVV95cUxNSU9BVDQ1aGJmeDQ4R3lJSnBNNThBbHdMRFNOQjVIU1NKNWtyeEFid3RWU2x2dkE1SzREUE1oNzJ1UFVMdV9tSHlBMklzcXNXTnhzWDJZSnhLNGVpaGRyd0RZMV9jZW54OWhrS1pNclhwZzR3bU5pb0E0QjViV0NXU29pRUI2RGJ4Sk1vNExsT1JBOGU5MFd0Tm1IaFdwb0RiUzYwczNLTFNiUnBsR2x5SnNMaw?oc=5",
         "description": "",
-        "pubDate": "2025-08-20T01:25:00Z",
+        "pubDate": "2025-08-24T20:54:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Downton Abbey 'iconic' props and costumes up for auction",
-        "link": "https://www.bbc.com/news/videos/c3dpzre97j4o?at_medium=RSS&at_campaign=rss",
-        "description": "Props, costumes and set pieces from the popular British historical drama Downton Abbey are being auctioned for charity in London.",
-        "pubDate": "2025-08-19T18:51:43Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/a2f5/live/fe43bad0-7d2c-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "With 'Highest 2 Lowest,' Spike Lee puts a hip-hop spin on Kurosawa's 1963 classic",
-        "link": "https://www.npr.org/2025/08/19/nx-s1-5503407/with-highest-2-lowest-spike-lee-puts-a-hip-hop-spin-on-kurosawas-1963-classic",
-        "description": "Lee's new film centers on a music mogul who faces a moral dilemma when kidnappers mistakenly hold his friend's son ransom instead of his own: Will he risk it all to save a child who isn't his?",
-        "pubDate": "2025-08-19T17:27:55Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Watch: Filming of new Harry Potter series spotted in London",
-        "link": "https://www.bbc.com/news/videos/ceqyv7wr9nlo?at_medium=RSS&at_campaign=rss",
-        "description": "Actors including Dominic McLaughlin and Nick Frost, who play Harry and Hagrid, are spotted in Southwark.",
-        "pubDate": "2025-08-19T14:38:00Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/bfcb/live/bb40e200-7d07-11f0-83cc-c5da98c419b8.jpg",
-        "bias": 0
-      },
-      {
-        "title": "'Can't stop. Won't stop': Documentary filmmakers face federal funding shortfall",
-        "link": "https://www.npr.org/2025/08/18/nx-s1-5490964/documentary-funding-cpb-pbs",
-        "description": "PBS has been a home for independent documentaries for more than 50 years. But with the closure of the Corporation for Public Broadcasting, nonfiction storytellers have to figure out a way forward.",
-        "pubDate": "2025-08-18T14:00:00Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "From Sir Sean with love: The legacy that is helping young filmmakers",
-        "link": "https://www.bbc.com/news/articles/cpdj660j94go?at_medium=RSS&at_campaign=rss",
-        "description": "A foundation set up in Sir Sean's name helps give young people a start in the film industry.",
-        "pubDate": "2025-08-18T05:12:01Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/50b9/live/95894c70-7a9e-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Terence Stamp, '60s British film legend and star of 'Superman,' dies at 87",
-        "link": "https://www.npr.org/2025/08/18/nx-s1-5505466/actor-terence-stamp-dies",
-        "description": "The English actor was best known for starring as the arch-villain in the original",
-        "pubDate": "2025-08-18T04:10:45Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Why are there so many movies about the movies?",
-        "link": "https://www.npr.org/2025/08/17/nx-s1-5500522/why-are-there-so-many-movies-about-the-movies",
-        "description": "NPR's film critic Bob Mondello and",
-        "pubDate": "2025-08-17T21:05:58Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "'Your Favorite Scary Movie' is a new history of the Scream franchise",
-        "link": "https://www.npr.org/2025/08/17/nx-s1-5314940/your-favorite-scary-movie-is-a-new-history-of-the-scream-franchise",
-        "description": "NPR's Ayesha Rascoe asks Ashley Cullins about the \"Scream\" franchise. Cullins writes about it in her book \"Your Favorite Scary Movie.\"",
-        "pubDate": "2025-08-17T13:02:08Z",
-        "source": "npr.org",
-        "image": "",
-        "bias": -1
-      },
-      {
-        "title": "Sugar Hut, spray tans, stilettos: Towie turns 15",
-        "link": "https://www.bbc.com/news/articles/c98l693gylro?at_medium=RSS&at_campaign=rss",
-        "description": "Love it or hate it, there is no denying that The Only Way is Essex thrust Essex into the spotlight.",
-        "pubDate": "2025-08-17T05:30:33Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/9c0f/live/616b6670-7b3f-11f0-ab3e-bd52082cd0ae.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Topshop returns to the High Street, but can it get its cool back?",
-        "link": "https://www.bbc.com/news/articles/ckgl4w1zkypo?at_medium=RSS&at_campaign=rss",
-        "description": "For many, the stores defined their childhood. Now the retailer says it is reopening them, and held its first catwalk for years on Saturday.",
-        "pubDate": "2025-08-16T17:42:42Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/c338/live/86c853f0-7aaa-11f0-919c-e1195b87955e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Blackpink: K-pop band make 'epic Wembley dream' come true",
-        "link": "https://www.bbc.com/news/articles/c36jz730114o?at_medium=RSS&at_campaign=rss",
-        "description": "The quartet have become the first Korean girl group to headline a concert at London's Wembley Stadium.",
-        "pubDate": "2025-08-16T01:20:20Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/0cff/live/1b458520-7a3d-11f0-a34f-318be3fb0481.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Ted Lasso's Nick Mohammed just can't stay away from Richmond",
-        "link": "https://www.bbc.com/news/videos/cd9jkyx3lygo?at_medium=RSS&at_campaign=rss",
-        "description": "The actor and comedian joins Josh Widdicombe in the Radio 2 studio for a chat.",
-        "pubDate": "2025-08-14T16:08:59Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/4e7c/live/29095670-7914-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "'One-take wonder': David Jason on that  iconic chandelier scene",
-        "link": "https://www.bbc.com/news/videos/ce93dv90k9ko?at_medium=RSS&at_campaign=rss",
-        "description": "The British actor who portrayed Del Boy in the TV show Only Fools and Horses told BBC Breakfast about how the backstage crew reacted to the show's famous chandelier scene",
-        "pubDate": "2025-08-14T10:08:20Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/95ab/live/6530d310-78f3-11f0-8071-1788c7e8ae0e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Does anyone still send postcards?",
-        "link": "https://www.bbc.com/news/videos/c627nwpg5q9o?at_medium=RSS&at_campaign=rss",
-        "description": "The BBC speaks to people on Hastings Beach to find out whether postcards are making a comeback.",
-        "pubDate": "2025-08-12T09:35:52Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/e9ae/live/1cb01ba0-775e-11f0-a975-cb151ca452f4.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Mexican-American designer apologizes for Adidas sandal design accused of cultural appropriation - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitgFBVV95cUxNcEZmUmZSYkhJQ3k1Q1NVSDY4aHZ1Rm9DVy1PSjZaRzI5SGVUN3pKQ1lPenlGeU9ZcUZpWEVwb0gzRTh3WjlnX0wwaXl1R1pDaHA2RTlpMG42a09yTWFpR0RRV01PR19sOFBHRmx0LUMyTE1QbkZKb0xmUnpGc2hPb2s5UjBxTTdnc21jYlpDZDdqZGpXSXBjWFhDd1VnaUlYREJoMi1PTTBzd1YwMkFCS2hkMDZ3QQ?oc=5",
+        "title": "Lacey fire crews respond to blaze near homes. Find kids with lighter - The Olympian",
+        "link": "https://news.google.com/rss/articles/CBMibEFVX3lxTE1NdlI3c1Y5eGJEdVJjRDZfdFo3ZmEyRkg1NVhaQzlSV1Z4NUh5UkhfMFBtYUg4R1YxWFluQS1Pcy0yTDhzVUlHbnZCUlFVenFMcm1HRVlOXzNxV0t3aHZuQ1JOc0hnWVBWVV9fRdIBbEFVX3lxTE8tcVRJQ1FCQXZzeXo1bWJDREtEWmFLRy1zZUNfd3FfUU9mSDhZTFVNYUhZcUQ2RFkwWmVWalRqT1lRcTZIa1FSZzZKS3FCa2p3Qm1EM2J4bjlMSl9EaEtJY0l4bjYwVktuRE93TQ?oc=5",
         "description": "",
-        "pubDate": "2025-08-12T07:00:00Z",
+        "pubDate": "2025-08-24T20:53:14Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Watch: Royal Albert Hall hosts first overnight Prom in decades",
-        "link": "https://www.bbc.com/news/videos/cx2747j72g6o?at_medium=RSS&at_campaign=rss",
-        "description": "\"The energy in the room has just been so incredible\" organist and curator Anna Lapwood told the BBC.",
-        "pubDate": "2025-08-09T08:59:36Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1378/live/93c0f650-74fd-11f0-a20f-3b86f375586a.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Matt Rogers talks bringing zeitgeisty Las Culturistas Awards to TV for the 1st time - AP News",
-        "link": "https://news.google.com/rss/articles/CBMisgFBVV95cUxNNDUzSWpwZG1ZUERKaVFTRlJyZGRaUnFPYUpHY2Z3RHRiRVRES09HRUpiZGI5QnJLY3lnaHp6dUlJVHV0LTlmczgzYVJNSVAxOGtxUGlxWEQ1aTE5a0t5WEpvel9GcE9vZmp1ekdqMEJTXzRJWVE0ZFprN3J2dHY3U0U1YWpScldCc1E1Wkp2eWZOdFNJMFRaMnBmUXZNSFk1VW1HZEk0RFBkbkMyUkk5c2Z3?oc=5",
+        "title": "Emergency crews on scene for house fire in Arlington - WPXI",
+        "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxPNzdfOE80c3hwMVp0bGxlNUFqZjdVM3hNbGZpZVJ1ZGRzdk1tRTU1djFUSjZ3WFJqSllBM0JLSkV6aTdHQzlDeWpDVGx6MWRKQ2hOS1BYU0E0c1MxZFBJSW5SMFBhUEtPVVBCRmdOMFkwSDBBZUVsR29fdUVYNUIyNUhHTTA3SjloTXlBV2FuQ1Z2WEt5UkozMG51eUNJUmRSY3RfRtIBuAFBVV95cUxPWVFhTmhNYlB5ZGUtbTFEMzVnU3lWZmQwVU53X2xQN3U2TGQ1ZVhCUURiR2lpVDJDaWpYQWh0QVlPd0xrcHk1UGlsUHBhSm00bHVKTHhpR0I3U3dkbjlZNjNxZzcyVjRoV2paQV9hdlNMZm1FMGVjdTVUMk5FcnVweDlsdm1FSzVFXy1KTlZVYXpIbEJfVjM5THNIYTlSdVl3OXVsU1hJTE1VVW9OdmhELW5OWDhGRERn?oc=5",
         "description": "",
-        "pubDate": "2025-08-01T07:00:00Z",
+        "pubDate": "2025-08-24T20:48:47Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Burial site of the Chancay culture found in the outskirts of Lima - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiwAFBVV95cUxOcnVvRG1rM01ENV90WjhNd2J5OEZacWdxaEpjTWRmdkIwM2NqSVhHZWh2UFRGQWxSWEZnbF9Bb3k4T0h2dnpUdjlnSjJ1cDc3d1R4R3VuMjJ5QzhJeDBvQ1hLMm5UV1hVcnJlZnFZUTdiOGM0Rm1ZZkUtV0JKczFtdGdvTm5FeTlMVkJaNnRsRGxQOWlKTzFYZTlueURGWEN0STBXWmlhLWxaX3Nvdk9RSlVMWkdxaHQyMW5pMVdPLWQ?oc=5",
+        "title": "1-1 Fire is burning in Lassen County east of Susanville - Action News Now",
+        "link": "https://news.google.com/rss/articles/CBMi1wFBVV95cUxNUjRSZjhpRDBIWTJNM0VvQlRuWllNUGhTd1JabVBaT3l2TUZ6R1NrOGpyZ0x2NWRPZEp0SzVlekZxbUx2T2hDY2lSZkFRLVpyOEt3YVlQcXEwdUdhemZ4UUhiYUpUcWFpQ2xVbF8wMURUYUd4cktybWplZjFXeThXMXBvYU1SQks1aFlWNEo5MGhobk1RRGZnSEV0X0pDZVk0VXh2c3RReWVJeV9rWTV2SnNZek1UZUtveUxIcWxFWmd4UDVDQTFRcERNcXJ4X0NJclJsanpnRQ?oc=5",
         "description": "",
-        "pubDate": "2025-07-31T07:00:00Z",
+        "pubDate": "2025-08-24T20:41:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "The reverse migration: African Americans relocating to Kenya cite heritage and restoration - AP News",
-        "link": "https://news.google.com/rss/articles/CBMimgFBVV95cUxNeTlKTWd2aUIwVFFmYlBWUGlHT0szNnF1aTVCRHFwYU5FdGdiTWZqRG1BZDRuZEZnOUJrc0s5Q0twSnFrNjh6R1BVenI3OHc3Q3JwM292OE01ME1VcjFBVGFUZFlMNXBSaEtBbTRnc2hPQkxzcVBTaXgyVWhQWGNJdVBGZlVaVTUxSmFWSDBEMkNCbWIwTzB2LWxn?oc=5",
+        "title": "Two families displaced after fire - Western Mass News",
+        "link": "https://news.google.com/rss/articles/CBMigwFBVV95cUxOM2tyWVpNdkdGQW5wTUpvLW1yYnFLbm9rWFpDRmc0VUFPeVF1ZWxoWGM3MkUzdDBibE4zd1BVT3JRV2ZoWlVLWjJ1b0lLZXdkOWdBMHBMUlpyWFd6dzUxX0R5WmV6Z2RlV25tblM4bUpKa2JsaGZpOGt1amt6UHU1bXlFRQ?oc=5",
         "description": "",
-        "pubDate": "2025-07-26T07:00:00Z",
+        "pubDate": "2025-08-24T20:39:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Hulk Hogan, icon in professional wrestling, dies at age 71 - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxQdFJwR0NhUkV2aG5URWh2bnF1bU5LRTdaVWU2RVozTkRuM3l4STAxcksyYkU0bkRGbnM3cXdNQWM4VE1SWnpETFM4cW5IdFU5TVBFeUx1Yi13OFREakNYakxGcUZiR0tITkphOHFyWk5GdzVZTkJROGkybVZZZ0tubzJKRF8zTzdudmpncmdsazg3WmFnMW95ak5QenBmRjNkdnVHRUlIbVdEdlk?oc=5",
+        "title": "Pickett Fire Poses Threat to Napa County, CA, Wineries - firehouse.com",
+        "link": "https://news.google.com/rss/articles/CBMivgFBVV95cUxOcDZNRUctbERwUVJhMVhyeHdmeWk3MG5WaEgwRF95d1NLYVhVSWJrNk9RR3d1YS1CaDhBRm81SG9QeFlOYkpHdl9ocm43YWpyZkhXOVo1eUxqZnhnZF9kVWxqblVRQ1QyUjc5YXZjVkZzRXJJY3J2QzRwVEtmTXpmcFlINUVYNDFKcHp4Q3RUMkl0MmVpS2VkUmJGdk8tZGRaRmRiV1BMZkVvdGczdE84ZUQwSWg0ZzRIXzh5SVh3?oc=5",
         "description": "",
-        "pubDate": "2025-07-24T07:00:00Z",
+        "pubDate": "2025-08-24T20:36:41Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Elijah Wood remembers Hulk Hogan as ‘fixture of pop culture’ - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitwFBVV95cUxQbHRFbzlkcnMwRlliajlIWnRRNWlpUTI1SlVEWUVzejVJT0JrVjVTb3FuandSMmFseXJNWV9sWUJxNGRzWmhOYnlqRWVJWFJOLUxPYmtvRi04MnA3MDJtTEF6amV5OG5zaHdaazBNc3R1YmFmWXVCT0w4WF9FblRYdHhyQldzUl8wLWdXdW5YMUVPbGVudXlmVVBqZEk3NWUzOXVpQld6Y2FwaWFpQnRQMm5pdDRlWk0?oc=5",
+        "title": "Flood advisory for Los Angeles Sunday afternoon caused by substantial rain - Fresno Bee",
+        "link": "https://news.google.com/rss/articles/CBMic0FVX3lxTE1Xd2NmRHZwUUlYYklYc1FtcFh5YUdNb0hKU0xBX3VNX2NHVGZkckFubG5aVUJuSGdNRFQyV0RvdTVWSkJPSm4tbXBBSnBOS29uZThfaGs3Wk5IUmxGZVQxU0dLRVFuOE5ndXFuQ0RELWFEOWc?oc=5",
         "description": "",
-        "pubDate": "2025-07-24T07:00:00Z",
+        "pubDate": "2025-08-24T20:31:05Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "‘We’re peeping toms now': Culture expert on THAT Coldplay moment - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiugFBVV95cUxNNG56OVNYa2podkhJc1RoZ0wtV1NDcnkydWZEdzNtU1R6Vnh1M2I4dnFrd1lYQVlGV0JzTDFvbDJYMW9mOHA2RDRyTkxfbnM1WXc2VDdfU3NZUkJVZklFZVp1eUlGYm5IZ1JnYkhsUmRzejhMNDN2QXVETjZUcFNBbW91amlXbWpHMnZCcUJhdGxGQ1lYV09odTR2Qk1CRkg0U3lwdTkyRXNMOTVYWl82Szl1NDJpdTJ5RlE?oc=5",
+        "title": "Video shows a large plume of fire and smoke in an Israeli strike on Yemen - CNN",
+        "link": "https://news.google.com/rss/articles/CBMiigFBVV95cUxNM3JWMWU3WWkwWlpaR1RGUEZpWm5laTVMX3R0MndMWmE0X3FYOTN3cV85M1NKRWg0SE5pazJDanFxWnpnOFY0Y0w5bFpLbFBuWTJLbm1aUWRNUkJYd2NIeEtHOExMZGtLUTZFalJ3NGFKcW1HZU5FdmVsWHR6a3ZJV01DTjhkT1k3YWc?oc=5",
         "description": "",
-        "pubDate": "2025-07-22T07:00:00Z",
+        "pubDate": "2025-08-24T20:31:04Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
       },
       {
-        "title": "Wild chickens take over Miami while some embrace roosters as a cultural symbol - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikgFBVV95cUxQazRUSjh4eENwXzBIa3lMdEdQckM5V1EtRzRzX1ZINk0xejlpaG0xZHNOemd2Y3hwZk9UUzF4U3phM2pZblF4V2ZiampRMmJrb3FackZqVmV5bUxEalpLbEZUNndGTUZ0TV9pUlM5SF90aXBHQjV6OGM5T25RQ3d0dXBjOGtVcU5zclNzd2xNOGQxdw?oc=5",
+        "title": "Carol Stream fire: Eric Neuman set house on fire on Hemlock Lane, causing explosion, prosecutors say - ABC7 Chicago",
+        "link": "https://news.google.com/rss/articles/CBMiwwFBVV95cUxNN09rcVgtWkR5NUFWSi1ZSHJiOTZ2TUl5ZGZHX0o5SmdRdHluUDAzV3FZMmFvN1h0NHJiREl3UTRPaVJrMkI2Z3dUaktmNnJXdTFDVGx1ekowZnVRSzZ3NHptT3ItV2hvRVpWdmJQd0tWTlJzcFNlbnZWWHRhaEhjekhrY2wxN0diSVBmYzF3bW5oYTB6QV9nN0kxUnFSSXFmWWF1TFBEdXNsRTR5UkpxdjRONGxRZFQzTENFQlc0VEhHZnfSAcgBQVVfeXFMTVhoXzdPLTlSRHNOYldjenpnMGs3UWRRTF9Kd1FaRmhGZWEyRmFwLVVHMnJGdTNvMnEzV3JKRFNRNUl4S05zQWNTRm1pUFJDUkpSM1BEanJGZkN1Tll1NUhzTko4Y3lBbldKMDZtczlhbWJjT09jdUlIWnBRZWQ0QzhXVGlNakJtWkdqanNTdXpmNHRONjdaeWlMUEltMFp2UTVzVVNMbWxGTF9WaldGa25CNWZGNGg0ZnRtS2ZEUFlmV2dqOE1GSlc?oc=5",
         "description": "",
-        "pubDate": "2025-05-25T07:00:00Z",
+        "pubDate": "2025-08-24T20:29:53Z",
         "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Pickett fire in Napa County grows, threatening homes and wineries - Los Angeles Times",
+        "link": "https://news.google.com/rss/articles/CBMiggFBVV95cUxQeDkwc0NxaEZDOEVpdWhnYjRkdnViZDUyRERXTl8wYmh2MkJmMGxZNER2a2hIbkFuQWhpQ3hONGpHYnExLVMtb0UxVTdFQTJlRUg4bEZkYloycjZWWnZiNUlXUHJ3enhhOGx6WDR3a2FXY2xDd05Iamx0UWxPVllvYkxR?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:29:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flash flooding, mudslides reported near Lee Fire in western Colorado - CBS News",
+        "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxOc0FpaGpybzdkMnV3NktRNGZ2QWZDMk8xTXhvN2ZNZllhdWgxTDZRNEJPM0w2aWV6cl9XSWlEamFXXzlXeDFWZGwwU0hLb0xxWmZUOEtZY2xNZGQxQ1QxX0JQNVMzeXBRRXVPeWppZGwxSHA3WnU5LUxDc0NMMmZVMzNFZEREQ1doZkFCQUlSb2FNYkk?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:25:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Charles City Fire Rescue responds to ‘major fire’ downtown on Saturday - KTTC News",
+        "link": "https://news.google.com/rss/articles/CBMimwFBVV95cUxOWVpuMUdYM2xlSzNjZHpuaWJiY0ViOUgwMS1sTUdGemo0SjhIbkZKM1lVUm9LbkllbXQ1MGtWS0RkbXZ3bi01REo3UzhHSk1CaEZCYnowaDVRLXprQnlXVkZEaVFqZWNpdVB2bk1pVDRldTBqWmp2bHRUbUo1dERfZEk2RW40M2Q2VEdJVHVjUmRpZ1F5elhfcGxib9IBrwFBVV95cUxQQmZDMDNpbFNrVGJfcm9FeWota1lOWGZOdUNtM2t4ei1rZGRxaXJoMmhWYjZqeVdpTE1zdHNuajdBc3hkOFdGSlNBclFoMGNJc0VoalBKaVRleHdib3A0dXNsaExmb2FacVVEc0ZUOVVVOGxHR1FfQkxOWHhkNHpfbWdiUFRkcEVhVFRfb2QyOVp5cjJIT3hjbU93SE1IMno4akN6UWZJMU01bUJvRGw4?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:24:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "2 people hospitalized after explosion in Lawrence County - CBS News",
+        "link": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5KTWxSXzQta0FZOWN3WUZZZUs4aXJIZDBKRkFydXB5NzJmWDVPWkNBSVlnNXFRdUNGdVdNM0dsV0pSVEM3WF9jTWlfNzgtS0FwMjFRaTZGRzB5RW5LU05lQ2NfVldpd0F0YUdvSDNtdl9JMGowUnJOVg?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:20:43Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood advisory affecting Mariposa County early Sunday evening triggered by heavy downpours - San Luis Obispo Tribune",
+        "link": "https://news.google.com/rss/articles/CBMieEFVX3lxTE1JU0hNSGZMel9Da1ZoRk5pbU9mVlZZSE1WbjNpcnhnZTV1UXRzUFRoUEN3T3Q4V3FCLW9WU3BRLUtYU2N5eXl4U3hWQVUyWm1RR1FUNVhnQ1gxV09UWFdkYmJ0eWdQaEdmazdfQlB1MzNuQzB0WnRHSQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:20:06Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Firefighters respond to J. Alexander's kitchen fire at Easton - The Columbus Dispatch",
+        "link": "https://news.google.com/rss/articles/CBMixAFBVV95cUxOZ2NrOWg1RFYwRVFOTDE2SHNlVDZnQmZiaVVDOG9veG15X2tZeXVPcVQwOG01NWoxOHotUWxjbWNFZEtNMWY5TlphQXR4bkxoQnRCZmljVFNxVnZlWV9xUGtOTEMwcmVPUjlKU1BTc0g0Mk9UaXZsSElSVEpMN2ZOdTluLUJfUDRGU1ZqTDJHZktod2haNnhDU3pOUlowWlF2TW1rQ3Rqa1ZJdzhpMDJxV20yeGhJcjVWMDhFMDZaalBOWWUz?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:13:47Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Lee Fire 86 percent contained; mudslide closes Piceance Creek Road - SteamboatToday.com",
+        "link": "https://news.google.com/rss/articles/CBMipAFBVV95cUxQYWRkZFZMbk90VG02cmV0TEpEdTlYaFdHZUl1aW1TTHBaRXk0WW9xa2pWMkhHU01JR2tVSGRGZjRWN0JWOW00ekFhSXZ4UDhHNlF3LUtZOE5tMTdXQ3ZMSjFHNER2ZHg5cExGcFVZZzNTVmVpMXliUUFSTHAyUktmamRoVWw1SWJoUHIxZ1RCUlNQWjh6ejRtY1E1WFhUMk5xclF1NA?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:06:37Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Kern County under a flood advisory Sunday afternoon triggered by heavy downpours - Modesto Bee",
+        "link": "https://news.google.com/rss/articles/CBMib0FVX3lxTFBQNGhqNjFCcTNtUlUxbWNPcHc0R2dWOXRRNndIRWJwNUEzRURyR1phV19ZSlhrb0xEN1ZTSDl2YjB2RHpoT2lMMWhzOXNQb0ZDMTFSb3A4dldhX2xKblk4aDVyWEpzd0Z1a2d0bEswMA?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:05:05Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "68-year-old woman dies in Burton house fire - Cleveland 19 News",
+        "link": "https://news.google.com/rss/articles/CBMihwFBVV95cUxOdjZFbVB1dFZkQm9iTkJIRVU2Q1o5aGRFTmhMSndSTmtzbHVibWdvQWV4OUpTN2tTMjJKcE5qVU5BaXJJaFpwaEozRG9GdUFRdkJCVzJRM2VNWXU2cU5hT1U2RER5NjgwLS0zSVg4bEJ6ZDk1UHByYTBwakZQU0hxU0pWM3F3NFk?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T20:03:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "LMPD detective hospitalized for minor injuries after rushing to help residents in apartment fire - The Courier-Journal",
+        "link": "https://news.google.com/rss/articles/CBMi3wFBVV95cUxOTDQtdm5JNWlSUkxXTENqZHl1eldocm5tS1dpNHJhdjl5TWJlMUhZOHd5VU9fVkFDbFZsS0dlWFRUczdLc1c2UldiS1JEWmFHVERYQjlld1lYaGp6c1R2bDNvWTc0QUhNWFhuOHk5QmM1M3VvNVpwdy14LVk5dFBPZlZldmdTdEdJUGh2b0NRcjVwSlNkdDZoLWt1OFpnQ0pvUF9pd2pqZUhyaTUxM3JQeHNKQnpzV2daaVpQN2lqbndmR1R2cUpMUm9kRHBNc2J3eDQyNmxabU9mak5uOWtR?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:57:09Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood advisory affecting Tulare County Sunday afternoon caused by heavy rain - Fresno Bee",
+        "link": "https://news.google.com/rss/articles/CBMic0FVX3lxTE13d2FKUVBiUlhzbmdKRTB5djVrTkpGaXZmNWFjR2JWQlhneU1WaEJCOXNwbS01eFRleVdyVG1oaWhCam8zMHpfUFljbFRDRlBBTTRYQ2hDQTY3TWRua2RVZkVCXzR4RTVXN2ZIOTl6Q0FLWUU?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:50:05Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Cottonwood Peak Fire gains acreage, containment - KOLO | 8 News Now",
+        "link": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxNLWVxVmRWRUVpTlVHX3pWT3VPNFdiTkdIbUhKYWd6YURRTnluWVJqRmdYczhxR2pYbUN5R08yRnpuSmtqVFo5b1RSdUxobEIwX0hxajhyUzdrdlJWd3l2ckhsYXVGRTE5NmJBXzE2bWNmMXdxMDhkS21aTXY3OXF0WlB0ME85bFZk0gGcAUFVX3lxTE8yQktGWVFxNmtwdWFtYmlSZFBPdHlvRWhSTzBBWEVGeVM2RTNMR2d3SVVQWnpEdEtoUG9CdHZsWEJoWFBLOWQ0dnNPSFJFWFc3cU1rTEVBeG1OSF81VTFoRjhyNGlXS3BoV2NOdWJzMVJuVDlnS1JWa2YweDF0aldnaWdBdTVXdldYekxVamRRUzZaQVpYdkwxZWhQYg?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:49:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Apparent lightning fire near Echo Creek Ranch Road held to under 11 acres - Park Record",
+        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxQQ3V6VlBEekdWN0xnanFuOGhlMWNCVHVheHM5T3M2ZjJ4T1M3dTlEck42M1IxNkZtdU1CejBnSmJDT2VMS0ZXWnV0akxZMnFkRWF2N0NWYnRBdjBWMllLSWdvcjJKX25wS1pDNm9Xc2NYRFVNVW9NVExrNTRaUzhCdUhmR1NOVnQ2aE9vSnNpQmtBZVVaY1ZPVFRUOTdIUzRXV0JVeEZTaXIxaXY1?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:45:59Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Strong winds fan Long Lake wildfire, prompting more evacuations - CBC",
+        "link": "https://news.google.com/rss/articles/CBMitgFBVV95cUxPV1NUNUVWSTZqSXZBSlZ0N19NZ0I5dXBkOEtVaXFNRXRCM1l1MkVlN29VNGhNQm54VHc2d3RIQnJIMGNPWjVla0pXWFNLMTFfMWRyamw0Q2k3b0hxZ2llMEl4WTBmS21UOFpDa3pzeVJkdTI3NjlETV9xYUNtX2tBWTl4RVZnU05yeUhaVVNUR0xKVzJJSjVIMmt4WmxrQkRWVmpGZ1VhNU51TzlFcjJEUG1yX1lFQQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:36:08Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "1 severely burned, 1 evaluated after electrical explosion in Lawrence County - WTAE",
+        "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxOdDJrWmRWZGtIME9TUEVNc1FhTy1JcFBTNnhYTktreGFwbGlkMTNxWm1hbjF3cjJaTkUxNXZ6NkRuZ0hyUmFuSXZHcE9rcUdVOXlDUE1NSVNrTGlVdDU4WlRHYkk4a2Y3ZVFZRE1QeHpsRzdUU2g1UV9qV0pHaXFiS1JuSUhscVRFM191cFR5NFJNY196VkZlS0lWTldZSk5ZcUk5SVNmejBMd1k?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:31:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Family escapes early morning mobile home fire in KY - WSMV",
+        "link": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxPYUVvXzFuN0x4dEt2N1ZQaGl2cmxIRHh4WG1XSnRzaS05MXczSFVLN2VxVTducUZ1NHhPRzJVWHk3NElIUU0yUmF2eHgtUjAzRkJKUDY0akh0NmN6RG9sXzgyTTQzbTdhVDBkMWZlMU0wMTM5eWJTc2VMMXpUNVh2WkpXR3V2MHNu?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:23:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "BAER teams complete Soil Burn Severity map for Dragon Bravo Fire - Arizona Emergency Information Network (.gov)",
+        "link": "https://news.google.com/rss/articles/CBMihgFBVV95cUxPVnQxR1pBMlVaWi15TDNLcGgxSk1NLVNjbXVHNkdCdWdhY05CTURJZW9pbUJ3VWRZZTl0cUh5ZFY4U3hDOGxHLTdybnhyYzNJTmVvYnRJU3VCeDkxUXVwUVF2Z21pd3FKWURoaEhuTFg0YWJ0d3JveVI2em1XRG5lR3E0UDZGQQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:22:44Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Family of five displaced after house fire in Moscow - KREM",
+        "link": "https://news.google.com/rss/articles/CBMiyAFBVV95cUxNR05WejFKUVVja2tKVHZvZThXc01jNW5qMGNmT0ZmU1BYU2g2TC1rczdsQmc0b2YwakJGd2FMSFliQkhmakxtS0hxdGJ3SldPNDh2aHhOX19fSklSaHdmVk04RVEtRnRQOWVsVXRPVE1yMVExNS1aemxXQzZRaTkyOXlmSWhyUE1GTElNN3VZZVQ3di00WUU1dURUUGZ3X3FDdjJTWWRuU3ZXaVhzN2EzLXdKRkdVa1NkakN1UHFQanZ0N3lxeGFwNA?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:22:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flat Fire in Oregon Grows to Nearly 22,000 Acres - The New York Times",
+        "link": "https://news.google.com/rss/articles/CBMickFVX3lxTE5MSEFRTGgwYW10SlZHaDRFR0lOVVFqQzdZR3ZUTG5xbzd0b2hrTGpYXzFfZk5GSnQ2YVZ0NGFjdlNmazMxMnhYblh5MjJKWDVRZWhJVEY3VkJKVHc1QkdBUzJKdXZTMDlwRXVhdldDbDFxUQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:21:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Pickett fire grows slightly overnight to 6,803 acres as containment remains at 11% - NBC Bay Area",
+        "link": "https://news.google.com/rss/articles/CBMijAFBVV95cUxNM3E1UWRvT1l4YlpYMFJ5d1BYaGlNOURqYnNneGpZRnRLTWlUdVA5dDFfZmdWRlFZRVEtb2FVNEMtSHFZcmtOTHc1ME9VOEl6UGw0Qk9PLW13cE54b1VHNXo3aVdGYUJKTlZSOHM2dTR4YWw3WUFWZk9pNkVFN0FKWW9EUWVIVjdSX0ZvQdIBlAFBVV95cUxOMnZ1SkJFc1N0R2tsU3kwUkxvTWNIalAyLVY5bFdYVGI2M2toaFQ5bXRUYWRUNjM5Q0tEUVBsM1U5aHF0QzVid0Z1MWtvTGFHbUNEeFpXcDRlMTZpcEpIaGpNbGxnLUx2cGtDSW8yY3hkb3UwYmNUOE5vdWg2b2lrdkFONDdOVXdEZkp1RlFvWTlJN1gx?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:16:54Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Split Top Fire burns 4,000 acres northwest of Aberdeen - KMVT",
+        "link": "https://news.google.com/rss/articles/CBMiiwFBVV95cUxPbmRxWkFzajhIZUNuSmRWQ1JfdVhnMjdHY2FLRktGXzBjNXlpWEVZSzg5SXlkaEo2UWl5YndTN0NoMFBURlA1ajZhdFhSNlVWTlpOalhoZmt6MFo1WnZ6Q0FqMnNGU3JvTGtyR01NS2hqeTlTVWRxejVlV3ZGd0J2akVWdl9wOE1BZmZj0gGfAUFVX3lxTE1Ya2UyV1VlWHVpNnBrd18tZzNvdVJZRFNVMlJzRGtvYXdYWEJwZzJZdVBLaU9rSG1kei0yelFyOXdPTTRYRk1ZOHhkZ0JhWjhBSGlRSF85N3B6T0xTSU1RLTMwUnZoR2JCTVRKNU5CUG1kX0NxQXZMWjZNWEVkd0ZLSU0wSlJKRmFUdWgxQ2ZTV0xicUNwandjeVFoQ1Rpcw?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:14:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Wildfire Map Spotlight: Flat Fire, Central Oregon - IQAir",
+        "link": "https://news.google.com/rss/articles/CBMihAFBVV95cUxOamJYWDJXZDF6TnE5R1FnMXhpS3ZQVTdreW5jMjdqaG1pXzBjelBJQ2pIVk1ZVUVleFA5QUdVN1FFbnAzY05FT0huQThCTmhDNm5OdHdBWS02bXR6MFF4S0tzUVlMYzhTLXprbjNhQjBySnpaNzhMLWVLaFZ0ajNBTGVNbnA?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T19:01:25Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Bus pull event held in Altadena to raise money for Eaton Fire victims - ABC7 Los Angeles",
+        "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxQeHlRd2J6UHVSczNuVHFXU0laYlRYNjRlUzBGdjN3RGhOV1RuYmxCVFdSSHRQMTZOckZ5Mm5LR3oydlA5bE9lZ2Rpck9ZR0REMXkxcHhwVmxzMmxWY2doQnV0LTBCbGxPZFF4U0lqUzNCa3R1VnRVb01neHMxNjN4dHBSUjRYNGFKT0hHX3hPMy1ZRW00RUHSAZsBQVVfeXFMUFRtQjRKZGJxMEt4VG1IYTVCSERKLU1OU3l0dzVjU1JjaWxuWktXc1ktRmZ0LVEwZVh1QnJOU0hkb3l3TzVubWd6ekkteXJkYlRUOTZzM3Nvb3ljS1RmYjNHUHBPcVlRTm16MV9tLUJvVFVqLXliUDVtckFKTGJ4RTdrdXlzRWNLNWdZb2lyX1FPWGtBVTEtR3hCWGs?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:59:35Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flat Fire Morning Update – August 24, 2025 - Central Oregon Fire Information",
+        "link": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxOazRzeURDdjNLaHhuMC04R29GMW1fNm5ULUViVzhwdERqZ3QwcHoyZGdzdVk2WFVYaUdmaEpPa2VKSTVYcDdvNGRJT1F6TVlfbW1PTXhpd0JEZkZRODdWMXVzNVlOWmk4ZlFsSFY3R2U1ZDFjdk5ZWkZEeUVDSTNkRTUwOEJkSkVU?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:55:53Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Firefighters tackle large wildfire near Horsham - BBC",
+        "link": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE5jMG1CbTY2OXRLaUFMLU9XMWF4WF9wNWdJTGxPdkp2MDFvU3RPNlhDTjBQMHlZZ3hxQUdZV0ZLWUFvbHpCSnYzSmVnSEQ3cGtaeDB6S3VQaGg2Z9IBX0FVX3lxTE5HVDdISE1CTVgtVHVEY0Mxdk15WGlXbEZWZTk1ZU5mY2p6N1FPbktVQVZhYjVZNTlEX3pPNVNkWmRGTXZhNDg5NWI3U2JQM0lHdTNLdEJzV3VuQ0hPMmRN?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:54:29Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Zelensky vows to continue fighting as Ukraine marks independence day - BBC",
+        "link": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE5OTlRyTjB2OHoxM0N4VUc0U1BscldDa3JjeXAtaUwtY3VKUGpfRVlRZ0NFM0IyQTA5elNuTHhoYk9lMEJ2d1BzVVpxRmVXUE44bGZMWjVpWEE5UdIBX0FVX3lxTE1vREcyVlRDNXQ4TEp4eVV4R0tacEtmLTlOZWFzME9oTk5aN2c3dm5MTWJnVWMzOC1nMlhMRHBZSU1ObngxVjU3a05MMWM5MHNlUkFIY1RNclYxOGJQbGNn?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:42:54Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Crews respond to abandoned building fire - Hawaii News Now",
+        "link": "https://news.google.com/rss/articles/CBMihgFBVV95cUxNSk5RMW42LXNvQlBHZ05Dd05jMVcySk5ZYWVBa3c4RWUzdV9HaVE3WFBiSDRpdnZXME4zcHYtQ1lPWEJrdUFXUmc4SnRIbVpzTFFWdnZDTXRNdE1kLW5PZUhnZ3ByRGFtOHJtaU5GNHlUQjFraDM4UV9HSzloTlJSdVhlUFFIUdIBmgFBVV95cUxNaHJubVRuZEt6clppbzV3R2pPU2tUX2F2b3VRUHhod2l1R2dESGFHNS1oZW1BdUgxUXlXOFloRm9MakliYXlseF83NDM0LW5WLUUwZzd6SHJNM2VLemlrV1ZkVTluREF5LUVkbk9hX2FlS0tpNUVscllZQjVtRkZlRWhsSmRKWUJGUVNoSzRybk9wTVVwSkFKWlV3?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:40:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Russia accuses Ukraine of strike on nuclear plant in wave of drone attacks - The Guardian",
+        "link": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxNdkdvTkg2eVZoc24wVGpLdkI5eXFQazNQTVVycEw0N3FuMnJlajFPQVNzRURoT1RVN3hPLUdYNFFiZC0weVlDdHpVeFZOVExTM3BHZHFuZHAzMnZxTkRJdF9KM3I1S2d4RDV6cFI3V0Q1M1RYWG8xQ3luUG51Z3VORHMwdk5qNUxibGo1WFI5al9Hckg3LUdrY3lTaXZQM3VKSGZVMDNTUkc0dVU?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:29:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Crews respond to house fire in Woonsocket - WPRI.com",
+        "link": "https://news.google.com/rss/articles/CBMingFBVV95cUxOTWdOdlJRUF9pNzhtQWhqSWpnSzFPQVp2emd5OHk3WWg4X3lCXzkya3hVdjNNcm82c3RCZ19lUmN4Uk04aUhnQXlqU0o4cktUWWFONUg5X2pOVUU2UFBPN2dvRXNaS0tkUmtUQ25BM0J1UzV6NTZPUThPdklNMmxjQ2J5QWJqclk4c2xjSHBfNlRYZUd1Qk00eFZ6Z2l1QdIBowFBVV95cUxPaVpablotNUpzQkZodzhJbU9MNmxvbHB6eFdaNzd5MXJtYmhMUVpEb0NlU0J0T3A2TTlfQnY4ZGlVbWlfbjhSWHFZMHR1MEVNa2NJUE5GWkMyR0ZIYTd6S0dDc1NVLTh3VE5Da0lOVDRaRV9KTGxqam43VnBtSjNUeDM2aERwRHpCWmphOXJvLWRfZ0VybzFxOU1tQTBfUV9TU2pv?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:24:17Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Brothers hailed as heroes for stopping violent attack, saving woman in dog abuse incident - KEPR",
+        "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxQYU5DLWVBRjA4OVRtZDAxV05sdDEtUzVJeDVidEkxR0lkbUdXcF9Pc0xyVGo4eC1GWm13VU02QUduTUhGZHdOU0oxdFNxYi1fMHk1V28taEhCZVNWZWdXRC1RN3p3dlcySmRsWjk2a2hZQWNxVkE4TlhNcTRBS2FOOHpId2RzUmswanZTbTZ1MDdEb3R5RzFyYzRpeTAtdmlETkltX0pDdEozUFFaalE?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:11:32Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Plumes of smoke sent across Poole by grass fire - BBC",
+        "link": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE1VQ2RVTEI3RU9MeUJILU9hczVhUzU1WVNIWkpfYXQySVNTTFcxZ2dyOWl6aE5UVkpfZXFSTE1zd3o0Ump3UnNDT0JuMVpJcjVxWHZfY2FyWEZjd9IBX0FVX3lxTE5RX2JVcnhCWG94SFdwVDlMaWhTS2NKVlJpRXFES3YxeHVVdHRJb0EtV2lPQmZKdjgyTDNIYVlTY3c2QlBuYnZZYUwwV0x2R1pMcTFzdnVRemwxdVJiV2Y4?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:05:11Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "California wine country wildfire surpasses 6,500 acres, mandatory evacuations ordered - ABC News",
+        "link": "https://news.google.com/rss/articles/CBMingFBVV95cUxNeFZsdzRUX2ttb3VMVE1XQzBITHRNNmJBeVBGZVUxckIzUDdzVTF4TVBvYnhBdVY5TFlLNGlFZkFEUUQ5bEkyUF9UNldpbHpRQVFqTjJ5Qy05Q2NMcXhEekxyNWVnWHh2T1NOMzBmemxiZjBtbENvd1dIeHpic3UtczF3TmJRQWt3TTBvQnd0MXdxNTcxN183Wkh2WmNIUdIBowFBVV95cUxOU2pUYUVSS2FYdHhkSU5uaV81UWYxbFFaYk80c01sSnJ5SkRhd0NVaFI1MTJ1UVpSeDFBUUxwaDY4TmNaMnBrN2JIYWJURG5DaUE3Y0lSYnJ5eDBDd1BDV1MwTXNZcko0QjVKVl9jdFlubW1DcVBaR3kzUUI3NGlmMFhNZHFtM21zRUdMWVhTY3YxcE00ZGZxZ2d5d1ZVRVZGOUdZ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:01:01Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Fire 90% contained after Roseland explosion - WDSU",
+        "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxPWHd0TUNoclRvTVE2ZE5sWURSZ1pBNGRKdURTeF9JZ3hpWHFrMHUydENRRDhYRi1KVVJyNW5lSDZOZmNBeGxqdGNRZmpoRmZZZC1OODItNDJBLWFYX2dvRHJja0toN1F4T01CR05vdnRvb19yU3I1dVZSRk01aVJsTkF5R1VXcHVycnVzZll0Mk41U1NMZTUxa0hpZjcxWDZpdHBHbER1MUNFT0RYTlE?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T18:00:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Photos: Flat Fire burns in central Oregon - Statesman Journal",
+        "link": "https://news.google.com/rss/articles/CBMisAFBVV95cUxNNGJwYUdWbGRLazNFQkdNREw3SmMwYnNUWW1OSk5WeWVkZDR5QXcwNlZrOF95b3dKM3dXdGNyZzZ1RkplR2Z0STV0VV9rQzBtaDJVLUFUTmwwNDVNanJRdEFGcmFlNkhpRFc3T25rS3N6MVFyT0VhZGlZdWRZT1JQMUhvdFpwbG5vZ0xXYVdhU0R0cFRJYTF2SWlaeERVMzlyaHFldzdTa2YweXNxaEtBZw?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T17:56:19Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "5 shot, 1 fatally, as multiple gunmen open fire in New York City park: NYPD - ABC News",
+        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxPV09kYzZrSXZWd19JTGJiQkRZQ3BOMDhHRzlfd2NiUVRrc05MWldRNHpGYS1YRWVRaVN2aC0yMW5GWllDanRCekpiZzRnTHV3ZnBKblQzbldqakROUUVnaHllZWZta2lCNVZYX3FNX0cyU1lrdllvYVRlNnNOYlJHckRWb3BHZUpkUGVPVzUxV2PSAZYBQVVfeXFMTkQwTnNBS3F0M1p2bVBPMzhiMllocHJFbFhEZkJZNXo2WHJDWVVjdExLZ0FhTEExYVQ3T2wtb3poek5LQ21TSWVoNm9HSzk3aU5CRUJ1WTkyWHpMSVRKMUZRcE9nVDQtYVJZVnY2RlNoZXZnZlhDckVhSjAyUXRmcEZLTVEzc3JUYVZHZG4wZnZpVEtKWFB3?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T17:15:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Passenger’s device catches fire on American Airlines flight, sends smoke pouring into cabin - New York Post",
+        "link": "https://news.google.com/rss/articles/CBMingFBVV95cUxQckhLOU1TSml4VjNiZ29Pa05vbVRTT2ZWTTB6aDJfZG9GQ1FNS1l3WlRKdXJUVF9DVXNQNUVPMlZ6cVNmRjlkMUJjYXpmbW80cWhjMUhWakl2YlVaUDE1Uy1QU21XdkZlNVdUV05uRVIwMHBHeDZlc2xwM09rZkRKYnB1Ym5oNm4xbDRpZzdGNm1WYVRuQ0hfaHJxNWxtUQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T16:37:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Boy and man arrested over Gants Hill restaurant 'arson attack' - BBC",
+        "link": "https://news.google.com/rss/articles/CBMiWkFVX3lxTE1yMmlMb1RmSzQ0WmtpNmRhYTFWZDlTYVc4Ykhrb2k0ckhLMU1KSTdMZ2U5SDhtWlhBdHZ3SmxZekVZVmhkaktDTkVEbzF4a0dIMzNTYlB2SS1JZ9IBX0FVX3lxTE91YjN4S0pNRnZfUlE3VGtfLVZQYmxLbWk0NzM0MGI0M0J4X2lOem1iWHAySFVPVm0wRXl1bExwR2x5Um8wSWc5ejVpbVV1QmxyaW15OV9rd0hWUXByX0Z3?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T16:25:30Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Rampage Jackson 'deeply concerned' after son Raja's frightening multi-strike assault on wrestler Syko Stu - CBS Sports",
+        "link": "https://news.google.com/rss/articles/CBMi1AFBVV95cUxOdnFGZEstejNxM3BCaGVlQXFHQW9admdIZEpoeXZvSnpDMUtyNm5HRVpNSGpicnJ3YzU2TGZlaXhhcDNlQXo1a2VOTmxkaG5sc1ZIdVFhTUpzRkdQTFFULVlBbk54UDM4Y1FDY25IeUdmSnNGV0t6R0ZVSFFaVVY3VVFNTEdVYnNXbm01MU9pRW8xT2p1cmdVaVZpUmRPaHc5enUzX3J0cFZ1MERWOVNQQXpzS05kR1oxOWI3ZndFUzNUZ2FwZkw1MHVTRXpoMWFCMkpfSw?oc=5",
+        "description": "",
+        "pubDate": "2025-08-24T16:16:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      }
+    ],
+    "Infrastructure": [
+      {
+        "title": "Air Quality Alert issued August 22 at 9:24AM MST by NWS Phoenix AZ",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.546684Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Heat Advisory issued August 22 at 10:27AM PDT until August 27 at 9:00PM PDT by NWS Missoula MT",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.546295Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 22 at 10:53AM PDT by NWS Pendleton OR",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.545931Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 22 at 1:07PM MDT by NWS Riverton WY",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.545528Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 22 at 12:56PM PDT by NWS Missoula MT",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.545137Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 22 at 1:41PM PDT by NWS Spokane WA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.544774Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Hydrologic Outlook issued August 22 at 1:07PM AKDT by NWS Fairbanks AK",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.544354Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 22 at 2:20PM PDT by NWS Spokane WA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.543996Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 23 at 2:30PM CDT by NWS Fort Worth TX",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.543638Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Hydrologic Outlook issued August 23 at 11:37AM AKDT by NWS Fairbanks AK",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.543245Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 23 at 4:38PM MDT by NWS Missoula MT",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.542888Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Rip Current Statement issued August 24 at 1:35AM EDT until August 25 at 6:00AM EDT by NWS Jacksonville FL",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.542529Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Rip Current Statement issued August 24 at 1:38AM EDT until August 26 at 3:00AM EDT by NWS Melbourne FL",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.542147Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Hydrologic Outlook issued August 23 at 11:56PM PDT by NWS Elko NV",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.541791Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Special Weather Statement issued August 23 at 11:17PM AKDT by NWS Anchorage AK",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.541429Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Special Weather Statement issued August 24 at 3:17AM EDT by NWS Caribou ME",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.541029Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Rip Current Statement issued August 24 at 4:25AM EDT until August 24 at 8:00PM EDT by NWS Boston/Norton MA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.540646Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Beach Hazards Statement issued August 24 at 4:38AM EDT until August 24 at 11:00PM EDT by NWS Marquette MI",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.540224Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Wind Advisory issued August 24 at 1:25AM AKDT until August 27 at 4:00AM AKDT by NWS Fairbanks AK",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.539081Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Extreme Heat Warning issued August 24 at 2:49AM MST until August 24 at 8:00PM MST by NWS Tucson AZ",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.538724Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Extreme Heat Warning issued August 24 at 3:07AM PDT until August 24 at 9:00PM PDT by NWS Los Angeles/Oxnard CA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.537972Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Heat Advisory issued August 24 at 3:07AM PDT until August 24 at 9:00PM PDT by NWS Los Angeles/Oxnard CA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.537585Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Extreme Heat Warning issued August 24 at 3:41AM PDT until August 25 at 8:00PM PDT by NWS Medford OR",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.536840Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Heat Advisory issued August 24 at 3:41AM PDT until August 24 at 8:00PM PDT by NWS Medford OR",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.536456Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 24 at 6:04AM PDT by NWS Portland OR",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.535744Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:37AM EDT until August 28 at 11:00PM EDT by NWS Wilmington NC",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.535387Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "High Surf Advisory issued August 24 at 9:52AM AST until August 25 at 6:00PM AST by NWS San Juan PR",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.534672Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Rip Current Statement issued August 24 at 9:52AM AST until August 26 at 6:00PM AST by NWS San Juan PR",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.534307Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Watch issued August 24 at 9:01AM CDT until August 30 at 5:00AM CDT by NWS Quad Cities IA IL",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.533894Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:20AM CDT by NWS Aberdeen SD",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.533495Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:21AM CDT until August 27 at 1:00PM CDT by NWS Aberdeen SD",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.533102Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:39AM CDT until August 27 at 3:00AM CDT by NWS Quad Cities IA IL",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.532741Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:41AM CDT until August 27 at 7:00PM CDT by NWS Twin Cities/Chanhassen MN",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.531925Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:41AM CDT until August 28 at 7:00AM CDT by NWS Twin Cities/Chanhassen MN",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.531532Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:41AM CDT until August 29 at 1:00PM CDT by NWS Twin Cities/Chanhassen MN",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.531175Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:41AM CDT until August 25 at 7:00AM CDT by NWS Twin Cities/Chanhassen MN",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.530813Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:41AM CDT until August 31 at 1:00PM CDT by NWS Twin Cities/Chanhassen MN",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.530416Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 9:41AM CDT by NWS Twin Cities/Chanhassen MN",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.530026Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Heat Advisory issued August 24 at 7:55AM PDT until August 25 at 8:00AM PDT by NWS Hanford CA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.529576Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Extreme Heat Warning issued August 24 at 7:55AM PDT until August 25 at 8:00AM PDT by NWS Hanford CA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.529168Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Watch issued August 24 at 8:03AM MST until August 26 at 8:00PM MST by NWS Flagstaff AZ",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.528805Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 11:07AM EDT until August 25 at 2:00AM EDT by NWS Peachtree City GA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.528389Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Air Quality Alert issued August 24 at 9:10AM MDT by NWS Grand Junction CO",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.527670Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 11:26AM EDT by NWS Charleston SC",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.527270Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 11:26AM EDT until August 25 at 4:00PM EDT by NWS Charleston SC",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.526912Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 10:37AM CDT until August 30 at 7:00AM CDT by NWS Sioux Falls SD",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.526150Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 10:37AM CDT by NWS Sioux Falls SD",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.525794Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Warning issued August 24 at 10:59AM CDT until August 25 at 7:00AM CDT by NWS Milwaukee/Sullivan WI",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.525431Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Watch issued August 24 at 9:06AM PDT until August 24 at 9:00PM PDT by NWS Reno NV",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.524650Z",
+        "source": "",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Flood Watch issued August 24 at 9:19AM PDT until August 24 at 9:00PM PDT by NWS Hanford CA",
+        "link": "",
+        "description": "",
+        "pubDate": "2025-08-24T21:15:09.524261Z",
+        "source": "",
         "image": "",
         "bias": 0
       }

--- a/feeds.json
+++ b/feeds.json
@@ -1,38 +1,14 @@
 {
-  "World": [
-    "http://feeds.reuters.com/reuters/worldNews",
-    "http://feeds.bbci.co.uk/news/world/rss.xml",
-    "https://news.google.com/rss/search?q=site:apnews.com+world&hl=en-US&gl=US&ceid=US:en",
-    "http://www.aljazeera.com/xml/rss/all.xml",
-    "https://feeds.npr.org/1004/rss.xml"
+  "Life Safety": [
+    "https://news.google.com/rss/search?q=site:apnews.com+(deaths+OR+injuries+OR+evacuation+OR+missing)&hl=en-US&gl=US&ceid=US:en",
+    "https://news.google.com/rss/search?q=site:bbc.co.uk+(deaths+OR+injuries+OR+evacuation+OR+missing)&hl=en-US&gl=US&ceid=US:en"
   ],
-  "Politics": [
-    "http://feeds.reuters.com/Reuters/PoliticsNews",
-    "http://feeds.bbci.co.uk/news/politics/rss.xml",
-    "https://news.google.com/rss/search?q=site:apnews.com+politics&hl=en-US&gl=US&ceid=US:en",
-    "https://feeds.npr.org/1014/rss.xml"
+  "Events": [
+    "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/significant_day.atom",
+    "https://news.google.com/rss/search?q=explosion+OR+strike+OR+attack+OR+fire+OR+flood+OR+\"industrial+accident\"&hl=en-US&gl=US&ceid=US:en"
   ],
-  "Tech": [
-    "http://feeds.reuters.com/reuters/technologyNews",
-    "http://feeds.bbci.co.uk/news/technology/rss.xml",
-    "https://news.google.com/rss/search?q=site:apnews.com+technology&hl=en-US&gl=US&ceid=US:en",
-    "https://feeds.npr.org/1019/rss.xml"
-  ],
-  "Science": [
-    "http://feeds.reuters.com/reuters/scienceNews",
-    "http://feeds.bbci.co.uk/news/science_and_environment/rss.xml",
-    "https://news.google.com/rss/search?q=site:apnews.com+science&hl=en-US&gl=US&ceid=US:en",
-    "https://feeds.npr.org/1007/rss.xml"
-  ],
-  "Business": [
-    "http://feeds.reuters.com/reuters/businessNews",
-    "http://feeds.bbci.co.uk/news/business/rss.xml",
-    "https://news.google.com/rss/search?q=site:apnews.com+business&hl=en-US&gl=US&ceid=US:en",
-    "https://feeds.npr.org/1006/rss.xml"
-  ],
-  "Culture": [
-    "http://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml",
-    "https://news.google.com/rss/search?q=site:apnews.com+culture&hl=en-US&gl=US&ceid=US:en",
-    "https://feeds.npr.org/1045/rss.xml"
+  "Infrastructure": [
+    "https://alerts.weather.gov/cap/us.php?x=0",
+    "https://news.google.com/rss/search?q=outage+OR+alert+OR+\"transportation+failure\"&hl=en-US&gl=US&ceid=US:en"
   ]
 }

--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Daily Unbiased News</title>
+  <title>Critical Event Monitor</title>
   <link rel="stylesheet" href="styles.css">
-  <meta name="description" content="Daily unbiased news, refreshed automatically.">
+  <meta name="description" content="Trustworthy, officially confirmed updates on critical events affecting life safety, infrastructure and major incidents.">
 </head>
 <body>
   <div class="container">
     <header class="header">
-      <h1 class="site-title">Daily Unbiased News</h1>
-      <p class="tagline">Daily unbiased news, refreshed automatically.</p>
+      <h1 class="site-title">Critical Event Monitor</h1>
+      <p class="tagline">Trusted stream of official reports on life safety, major events and infrastructure failures.</p>
     </header>
     <div class="searchbar">
       <input type="search" id="searchInput" placeholder="Search news..." aria-label="Search news">
@@ -26,7 +26,7 @@
       <!-- News sections inserted dynamically -->
     </main>
     <footer class="footer">
-      <p>&copy; <span id="year"></span> Daily Unbiased News. All rights reserved.</p>
+      <p>&copy; <span id="year"></span> Critical Event Monitor. All rights reserved.</p>
     </footer>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- Rebrand site as "Critical Event Monitor" with tagline emphasizing officially confirmed incidents and focus on life safety, major events and infrastructure failures.
- Document new mission in README and update setup instructions.
- Replace feed configuration with sources and queries targeting critical incidents.
- Regenerate `news.json` using the new feeds.

## Testing
- `python fetch_news.py`
- `python -m py_compile fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab805451a8832db95c73e0037827ec