### PR TITLE
Add back to top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       <p>&copy; <span id="year"></span> Daily Unbiased News. All rights reserved.</p>
     </footer>
   </div>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top">Back to Top</button>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -12,7 +12,18 @@
     const contentContainer = document.getElementById('content');
     const tickerContent = document.getElementById('tickerContent');
     const yearSpan = document.getElementById('year');
+    const backToTopBtn = document.getElementById('backToTop');
     yearSpan.textContent = new Date().getFullYear();
+
+    backToTopBtn.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+
+    function toggleBackToTop() {
+      backToTopBtn.style.display = window.scrollY > 100 ? 'block' : 'none';
+    }
+    window.addEventListener('scroll', toggleBackToTop);
+    toggleBackToTop();
 
   const parseDate = str => new Date(str.endsWith('Z') ? str : `${str}Z`);
 

--- a/styles.css
+++ b/styles.css
@@ -238,3 +238,23 @@ body {
   border-radius: 8px;
 }
 
+/* ====== Back to Top Button ====== */
+.back-to-top {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  padding: 8px 12px;
+  font-size: 14px;
+  background: var(--accent);
+  color: #0b1220;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  z-index: 1000;
+  display: none;
+}
+
+.back-to-top:hover {
+  background: var(--accent-weak);
+}
+


### PR DESCRIPTION
## Summary
- Add fixed "Back to Top" button that appears on scroll
- Style button to sit at top-right away from article content
- Wire up script to show button after scrolling and smooth-scroll to page top

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07979c4f8832d9eb8d4b666b49078