### PR TITLE
feat: add gaming section for new releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ manual intervention.
   sources such as Reuters, BBC, Al Jazeera, NPR and AP (via Google News).
   The feed URLs are defined in `feeds.json` and can easily be extended or
   modified.
+- **Gaming first:** A lighthearted **Gaming** section kicks off the page with
+  fresh release announcements pulled from Steam, Nintendo and indie platforms
+  like itch.io.
 - **Category sections:** News items are grouped into major categories
-  (World, Politics, Tech, Science, Business, Culture). Each section
+  (Gaming, World, Politics, Tech, Science, Business, Culture). Each section
   displays up to 50 of the most recent unique headlines across all sources.
 - **Duplicate filtering:** Articles are deduplicated by title across all
   categories to avoid repeating the same story from multiple outlets.

--- a/data/news.json
+++ b/data/news.json
@@ -1,6 +1,458 @@
 {
-  "lastUpdate": "2025-08-29T17:45:42.440574Z",
+  "lastUpdate": "2025-08-29T17:49:16.468553Z",
   "news": {
+    "Gaming": [
+      {
+        "title": "Platofrmer - Nikola Latković [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platofrmer-nikola-latkovi",
+        "description": "",
+        "pubDate": "2025-08-29T17:45:21Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Busca Gemas (Rafa Belmonte) [Free] [Windows] [Linux]",
+        "link": "https://zonabitsacademy.itch.io/busca-gemas-rafa-belmonte",
+        "description": "",
+        "pubDate": "2025-08-29T17:41:23Z",
+        "source": "zonabitsacademy.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Busca Gemas (Sergio Najarro) [Free] [Windows] [Linux]",
+        "link": "https://zonabitsacademy.itch.io/busca-gemas-sergio",
+        "description": "",
+        "pubDate": "2025-08-29T17:34:46Z",
+        "source": "zonabitsacademy.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Platofrmer - Nikola Adžidović [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platofrmer-nikola-adidovi",
+        "description": "",
+        "pubDate": "2025-08-29T17:32:26Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Busca Gemas (Luis Rodríguez) [Free] [Windows] [Linux]",
+        "link": "https://zonabitsacademy.itch.io/busca-gemas-luis-rodrguez",
+        "description": "",
+        "pubDate": "2025-08-29T17:32:03Z",
+        "source": "zonabitsacademy.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "cuida tu mundo (CTM) [Free] [Other]",
+        "link": "https://mago-exotico.itch.io/cuida-tu-mundo-ctm",
+        "description": "",
+        "pubDate": "2025-08-29T17:31:55Z",
+        "source": "mago-exotico.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Busca Gemas (Abel) [Free] [Windows] [Linux]",
+        "link": "https://zonabitsacademy.itch.io/busca-gemas-abel",
+        "description": "",
+        "pubDate": "2025-08-29T17:26:21Z",
+        "source": "zonabitsacademy.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Undertale Boss [Free] [Action]",
+        "link": "https://cookieheart.itch.io/undertale-boss",
+        "description": "",
+        "pubDate": "2025-08-29T17:22:04Z",
+        "source": "cookieheart.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "PIG RUNNERS [Free] [Adventure] [Android]",
+        "link": "https://cmcooked.itch.io/pig-runners",
+        "description": "FUN GAMEEE",
+        "pubDate": "2025-08-29T17:11:18Z",
+        "source": "cmcooked.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "ii stupid menu. [Free]",
+        "link": "https://thatmodderhimgt.itch.io/ii-stupid-menu",
+        "description": "",
+        "pubDate": "2025-08-29T17:09:52Z",
+        "source": "thatmodderhimgt.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Lagusan Sa Biringan [Free] [Adventure]",
+        "link": "https://aironium.itch.io/gb-biringan",
+        "description": "You accidentally got into a hidden zone",
+        "pubDate": "2025-08-29T17:08:51Z",
+        "source": "aironium.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "The Little Picture [Free] [Platformer]",
+        "link": "https://tearai.itch.io/the-little-picture",
+        "description": "",
+        "pubDate": "2025-08-29T17:05:34Z",
+        "source": "tearai.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Profondeurs [Free] [Action] [Windows]",
+        "link": "https://salhiaa.itch.io/profondeurs",
+        "description": "",
+        "pubDate": "2025-08-29T16:51:58Z",
+        "source": "salhiaa.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Yao - Yao Game [Free]",
+        "link": "https://visst.itch.io/yao-yao-game",
+        "description": "",
+        "pubDate": "2025-08-29T16:51:33Z",
+        "source": "visst.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Space Animal Survivors [Free] [Action]",
+        "link": "https://mattoh.itch.io/space-animal-survivors",
+        "description": "",
+        "pubDate": "2025-08-29T16:41:56Z",
+        "source": "mattoh.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "knight platformer [Free] [Platformer]",
+        "link": "https://camdev.itch.io/knight-platformer",
+        "description": "",
+        "pubDate": "2025-08-29T16:40:19Z",
+        "source": "camdev.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "People Playground (WEB PORT) [Free] [Other]",
+        "link": "https://aukak.itch.io/people-playground",
+        "description": "Port by 98corbins, advertised by truffled.lol",
+        "pubDate": "2025-08-29T16:40:02Z",
+        "source": "aukak.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Summit [Free] [Platformer]",
+        "link": "https://skib77.itch.io/summit",
+        "description": "For Brackeys Game Jam 2025.2",
+        "pubDate": "2025-08-29T16:30:57Z",
+        "source": "skib77.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Cookies Gone Critical [Free] [Platformer]",
+        "link": "https://drowning-toaster.itch.io/cookies-gone-critical",
+        "description": "",
+        "pubDate": "2025-08-29T16:30:53Z",
+        "source": "drowning-toaster.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Eyes on Paradise [Free] [Adventure]",
+        "link": "https://wesplatt.itch.io/eyes-on-paradise",
+        "description": "A Twine game developed for the Investigative Journalism Game Jam with Floodlight Gaming",
+        "pubDate": "2025-08-29T16:29:03Z",
+        "source": "wesplatt.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Bad Brand Blaster [Free]",
+        "link": "https://graysonsgraphics.itch.io/bad-brand-blaster",
+        "description": "",
+        "pubDate": "2025-08-29T16:25:03Z",
+        "source": "graysonsgraphics.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "ShootingZ [Free] [Shooter] [Windows]",
+        "link": "https://vaes-developer.itch.io/shootingz",
+        "description": "Singleplayer, Short, Shooter, Zombies",
+        "pubDate": "2025-08-29T16:22:29Z",
+        "source": "vaes-developer.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Assunção: O jogo [Free] [Adventure] [Windows]",
+        "link": "https://msbugado.itch.io/assuno-o-jogo",
+        "description": "",
+        "pubDate": "2025-08-29T15:55:43Z",
+        "source": "msbugado.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "2014 Velociraptor Epilepsy Simulator [Free]",
+        "link": "https://pabloaramar.itch.io/2014-velociraptor-epilepsy-simulator",
+        "description": "this is the game ever",
+        "pubDate": "2025-08-29T15:41:20Z",
+        "source": "pabloaramar.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "The Cat Hero [Free] [Adventure] [Windows]",
+        "link": "https://red-fish-studio.itch.io/the-cat-hero",
+        "description": "Steal food for your fellow cats.",
+        "pubDate": "2025-08-29T15:36:07Z",
+        "source": "red-fish-studio.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Dark Man YCA 0.1 [Free] [Windows] [macOS] [Linux] [Android]",
+        "link": "https://horras-studio.itch.io/dark-man-yca-01",
+        "description": "",
+        "pubDate": "2025-08-29T12:32:05Z",
+        "source": "horras-studio.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Slot Machine - Crazy Fruits [Free] [Simulation]",
+        "link": "https://teamxz.itch.io/slots-fruit",
+        "description": "",
+        "pubDate": "2025-08-28T23:24:44Z",
+        "source": "teamxz.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Nasher Jaw's Chapter 2 [Free] [Windows] [Linux]",
+        "link": "https://zack1256.itch.io/nasher-jaws-chapter-2",
+        "description": "",
+        "pubDate": "2025-08-27T18:15:07Z",
+        "source": "zack1256.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Terry's Space Race [Free] [Adventure]",
+        "link": "https://fireflies-studios.itch.io/terry-space-race",
+        "description": "An arcade interactive space race for up to two players",
+        "pubDate": "2025-08-25T10:37:05Z",
+        "source": "fireflies-studios.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "GRAVIMATIC [Free] [Platformer] [Windows]",
+        "link": "https://shlumptee.itch.io/gravimatic",
+        "description": "Dodge asteroids and compete for the best possible score!",
+        "pubDate": "2025-08-07T20:35:36Z",
+        "source": "shlumptee.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "fiction-interactive.fr - Révélation du thème ConFI2026 [Free] [Interactive Fiction]",
+        "link": "https://crocmiam.itch.io/fifr-revelation-du-theme-confi2026",
+        "description": "Découvrez le thème du concours 2026 !",
+        "pubDate": "2025-08-01T10:27:12Z",
+        "source": "crocmiam.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Carter Burgess Legendary Air Adventure [Free] [Adventure]",
+        "link": "https://piratzfan.itch.io/burgess",
+        "description": "A man's quest to save rock and roll",
+        "pubDate": "2025-07-09T22:21:12Z",
+        "source": "piratzfan.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - SCUM",
+        "link": "https://store.steampowered.com/news/246601/",
+        "description": "",
+        "pubDate": "2025-06-17T14:55:24Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "AshCore [Free] [Windows] [Android]",
+        "link": "https://ashmangt.itch.io/ashcore",
+        "description": "",
+        "pubDate": "2025-03-08T20:14:37Z",
+        "source": "ashmangt.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "You Were Here Before [Free] [Visual Novel]",
+        "link": "https://interactivedreams.itch.io/youwereherebefore",
+        "description": "A game poem about memory and nostalgia",
+        "pubDate": "2025-03-06T03:54:43Z",
+        "source": "interactivedreams.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Foundation, 25% off!",
+        "link": "https://store.steampowered.com/news/237790/",
+        "description": "",
+        "pubDate": "2025-01-31T15:03:00Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Canvas Painter [Free]",
+        "link": "https://cnichol2502.itch.io/canvas-painter",
+        "description": "",
+        "pubDate": "2024-05-12T00:47:42Z",
+        "source": "cnichol2502.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Unending World [Free] [Role Playing]",
+        "link": "https://valice215.itch.io/unending-world",
+        "description": "Started to add dialogue and story. Prologue is now complete",
+        "pubDate": "2024-02-28T15:39:21Z",
+        "source": "valice215.itch.io",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - The Universim",
+        "link": "https://store.steampowered.com/news/215594/",
+        "description": "",
+        "pubDate": "2024-01-22T18:01:40Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Cowbots and Aliens",
+        "link": "https://store.steampowered.com/news/214495/",
+        "description": "",
+        "pubDate": "2023-12-24T23:03:27Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Kodon",
+        "link": "https://store.steampowered.com/news/213793/",
+        "description": "",
+        "pubDate": "2023-12-10T20:20:25Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - RAILGRADE, 25% off!",
+        "link": "https://store.steampowered.com/news/210653/",
+        "description": "",
+        "pubDate": "2023-10-13T07:00:13Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Kynseed, 10% off!",
+        "link": "https://store.steampowered.com/news/166893/",
+        "description": "",
+        "pubDate": "2022-12-06T15:00:37Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Quake Champions",
+        "link": "https://store.steampowered.com/news/142057/",
+        "description": "",
+        "pubDate": "2022-08-18T16:09:32Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Good Company, 20% off!",
+        "link": "https://store.steampowered.com/news/139789/",
+        "description": "",
+        "pubDate": "2022-06-21T13:02:05Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Raft, 15% off!",
+        "link": "https://store.steampowered.com/news/139741/",
+        "description": "",
+        "pubDate": "2022-06-20T16:56:52Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Factory Town",
+        "link": "https://store.steampowered.com/news/101463/",
+        "description": "",
+        "pubDate": "2021-11-17T18:01:38Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Ruined King: A League of Legends Story™",
+        "link": "https://store.steampowered.com/news/101398/",
+        "description": "",
+        "pubDate": "2021-11-16T16:25:13Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Killsquad, 20% off!",
+        "link": "https://store.steampowered.com/news/90261/",
+        "description": "",
+        "pubDate": "2021-10-21T10:09:19Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Legion TD 2 - Multiplayer Tower Defense",
+        "link": "https://store.steampowered.com/news/89382/",
+        "description": "",
+        "pubDate": "2021-10-01T14:45:01Z",
+        "source": "store.steampowered.com",
+        "image": "",
+        "bias": 0
+      }
+    ],
     "World": [
       {
         "title": "Madeleine McCann suspect to be released in less than three weeks",
@@ -309,6 +761,15 @@
         "bias": -1
       },
       {
+        "title": "MLB | Latest News, Stats, and Scores - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiP0FVX3lxTFBaTkhyRGJFdHFXZVFvanhPRFAxZmlEWjZWRDJxNWFVRzZGT2I1Zm1kNmVLLU9Henk1d2M5dFFDRQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-29T13:52:48Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
         "title": "Mauritania's coast guard says at least 49 died when a boat carrying migrants capsized this week - AP News",
         "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxPMFlqdU5hSHVWNG9hSHRIeTEybm1OSlZzYWo1dTg2UlZvcF8zRUszeVlYNmlZRDczMVBla0FmYVFITUk3aG1FYUV3dUotMzd1ZkRUQ2J3RG51aGJlSUFjZDlNMS1weTZDUklVNGZES0lQVzJnZ1o4X3BRSFRyeUpxdjN3c1htWG41VUhEeHhfLUZqRlZEbjNR?oc=5",
         "description": "",
@@ -442,18 +903,18 @@
         "source": "npr.org",
         "image": "",
         "bias": -1
-      },
-      {
-        "title": "Indonesians angry over politicians’ “crazy” wage increase",
-        "link": "https://www.aljazeera.com/video/quotable/2025/8/29/indonesians-angry-over-politicians-crazy-wage-increase?traffic_source=rss",
-        "description": "Social platform co-founder Abigail Limuria talks about the anger in Indonesia, where politicians are getting a wage hike",
-        "pubDate": "2025-08-29T11:40:55Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
       }
     ],
     "Politics": [
+      {
+        "title": "Asylum seekers to remain at hotel after appeal win",
+        "link": "https://www.bbc.com/news/articles/c8e1zd98k9no?at_medium=RSS&at_campaign=rss",
+        "description": "The Home Office and owner of The Bell Hotel in Essex win their legal battle at the Court of Appeal.",
+        "pubDate": "2025-08-29T17:47:39Z",
+        "source": "bbc.com",
+        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/f846/live/00c15370-84cc-11f0-9a8e-b57ad0129150.jpg",
+        "bias": 0
+      },
       {
         "title": "Trump ends Harris' Secret Service detail",
         "link": "https://www.npr.org/2025/08/29/nx-s1-5522066/kamala-harris-secret-service",
@@ -497,15 +958,6 @@
         "pubDate": "2025-08-29T15:58:42Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1c14/live/aac39da0-84e1-11f0-b391-6936825093bd.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Asylum seekers to remain at hotel after appeal win",
-        "link": "https://www.bbc.com/news/articles/c8e1zd98k9no?at_medium=RSS&at_campaign=rss",
-        "description": "The Home Office and owner of The Bell Hotel in Essex win their legal battle at the Court of Appeal.",
-        "pubDate": "2025-08-29T15:46:35Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/f846/live/00c15370-84cc-11f0-9a8e-b57ad0129150.jpg",
         "bias": 0
       },
       {
@@ -605,15 +1057,6 @@
         "pubDate": "2025-08-29T05:23:56Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/560f/live/12b1c6f0-8431-11f0-948c-5bc66b89f4bb.jpg",
-        "bias": 0
-      },
-      {
-        "title": "CDC gets new acting director as leadership turmoil leaves agency reeling - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxPd180RUcwMEJPaERVdmZ1cnU5MkVqamxCV1hJVm5PTkJrenJEUUNjblI3anpOMXpfZ1NMa19neGI0Rkk4M3BZSi12ZWhwVFg3TTdicnBxZU1JOXRIaW4xSndsVHZrSHBKQm16a0tDTHNUZDN2cE01WlV3cFh6b3FMTXJOSnNFdEJTVW1fai1KbF9HbnFfYzVpMDc4R3NWandDa3BEYlptdDMxMUZy?oc=5",
-        "description": "",
-        "pubDate": "2025-08-29T00:04:00Z",
-        "source": "news.google.com",
-        "image": "",
         "bias": 0
       },
       {
@@ -761,18 +1204,18 @@
         "bias": 0
       },
       {
-        "title": "'We didn't do enough': How U.S. policy failed Palestinians in Gaza",
-        "link": "https://www.npr.org/2025/08/28/nx-s1-5515620/israel-gaza-biden-famine",
-        "description": "As famine plagues Gaza, NPR exclusive reporting looks at the U.S. role in the humanitarian crisis. Many former officials NPR interviewed share a common refrain: Did we do enough to prevent this?",
+        "title": "Speaker Johnson pushed Medicaid cuts. His constituents worry about their own coverage",
+        "link": "https://www.npr.org/2025/08/28/nx-s1-5518040/speaker-johnson-medicaid-cuts-louisiana",
+        "description": "In Mike Johnson's district, not only could thousands of Louisianians lose coverage, health centers are bracing for a financial hit. They're hoping for additional funding to make up for Medicaid cuts.",
         "pubDate": "2025-08-28T09:00:00Z",
         "source": "npr.org",
         "image": "",
         "bias": -1
       },
       {
-        "title": "Speaker Johnson pushed Medicaid cuts. His constituents worry about their own coverage",
-        "link": "https://www.npr.org/2025/08/28/nx-s1-5518040/speaker-johnson-medicaid-cuts-louisiana",
-        "description": "In Mike Johnson's district, not only could thousands of Louisianians lose coverage, health centers are bracing for a financial hit. They're hoping for additional funding to make up for Medicaid cuts.",
+        "title": "'We didn't do enough': How U.S. policy failed Palestinians in Gaza",
+        "link": "https://www.npr.org/2025/08/28/nx-s1-5515620/israel-gaza-biden-famine",
+        "description": "As famine plagues Gaza, NPR exclusive reporting looks at the U.S. role in the humanitarian crisis. Many former officials NPR interviewed share a common refrain: Did we do enough to prevent this?",
         "pubDate": "2025-08-28T09:00:00Z",
         "source": "npr.org",
         "image": "",
@@ -902,6 +1345,15 @@
         "pubDate": "2025-08-26T11:46:00Z",
         "source": "news.google.com",
         "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Clarkson for PM, attacks on police dogs: Do Parliament petitions make a difference?",
+        "link": "https://www.bbc.com/news/articles/cg4xqn91rwlo?at_medium=RSS&at_campaign=rss",
+        "description": "People love signing petitions to get issues they care about debated by MPs - but some can't resist having a laugh.",
+        "pubDate": "2025-08-23T23:40:38Z",
+        "source": "bbc.com",
+        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d717/live/7bf0f3a0-8046-11f0-9048-d5a54170a86f.png",
         "bias": 0
       }
     ],

--- a/feeds.json
+++ b/feeds.json
@@ -1,4 +1,9 @@
 {
+  "Gaming": [
+    "https://store.steampowered.com/feeds/newreleases.xml",
+    "https://www.nintendo.com/whatsnew/feed/",
+    "https://itch.io/feed/new.xml"
+  ],
   "World": [
     "http://feeds.reuters.com/reuters/worldNews",
     "http://feeds.bbci.co.uk/news/world/rss.xml",


### PR DESCRIPTION
## Summary
- add lighthearted Gaming category fed by Steam, Nintendo and itch.io release feeds
- document new section and category order in README
- regenerate news data with gaming items at the top

## Testing
- `python fetch_news.py && echo 'script complete'`


------
https://chatgpt.com/codex/tasks/task_e_68b1e779986c832db20dad955d2f4a0e