### PR TITLE
Add User-Agent for feed fetching and include license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Daily Unbiased News
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ adjusted as needed.
 
 ## License
 
-This project is provided under the MIT License. See the [LICENSE](../LICENSE)
+This project is provided under the MIT License. See the [LICENSE](LICENSE)
 file for details.

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -130,7 +130,8 @@ def extract_items(xml_data: bytes) -> list:
 def fetch_feed(url: str) -> list:
     """Fetch and parse a single RSS/Atom feed URL, returning items list."""
     try:
-        with urllib.request.urlopen(url, timeout=20) as response:
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0 (compatible; DailyUnbiasedNews/1.0)'})
+        with urllib.request.urlopen(req, timeout=20) as response:
             data = response.read()
             return extract_items(data)
     except Exception:


### PR DESCRIPTION
## Summary
- avoid blocked RSS requests by sending a User-Agent header
- fix README license reference and add MIT LICENSE file

## Testing
- `python -m py_compile fetch_news.py`
- `node --check script.js`
- `python fetch_news.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1eb66add0832d83285ab2aaadf7c3