### PR TITLE
Prioritize Steam gaming news and require article images

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -168,8 +168,18 @@ def main():
                         continue
                     global_titles.add(title_key)
                     aggregated[category].append(item)
-        # Sort items by publication date descending and keep top 50
+        # For gaming news, enforce presence of title, link and image
+        if category == 'Gaming':
+            aggregated[category] = [
+                it for it in aggregated[category]
+                if it.get('title') and it.get('link') and it.get('image')
+            ]
+        # Sort items by publication date descending
         aggregated[category].sort(key=lambda x: x['pubDate'], reverse=True)
+        if category == 'Gaming':
+            # Stable sort to prioritize Steam entries
+            aggregated[category].sort(key=lambda x: x['source'] != 'store.steampowered.com')
+        # Keep top 50 items
         aggregated[category] = aggregated[category][:50]
 
     result = {

--- a/script.js
+++ b/script.js
@@ -95,14 +95,26 @@
       const list = document.createElement('div');
       list.className = 'article-list';
 
-      if (articles.length === 0) {
+      let displayArticles = articles;
+      if (category === 'Gaming') {
+        // Prioritize Steam entries
+        displayArticles = [...articles].sort((a, b) => {
+          return (a.source !== 'store.steampowered.com') - (b.source !== 'store.steampowered.com');
+        });
+      }
+
+      const elements = [];
+      displayArticles.forEach(article => {
+        const el = createArticleElement(article);
+        if (el) elements.push(el);
+      });
+
+      if (elements.length === 0) {
         const p = document.createElement('p');
         p.textContent = 'No articles available.';
         list.appendChild(p);
       } else {
-        articles.forEach(article => {
-          list.appendChild(createArticleElement(article));
-        });
+        elements.forEach(el => list.appendChild(el));
       }
 
       section.appendChild(list);
@@ -114,6 +126,7 @@
    * Create a DOM element for a single news article.
    */
   function createArticleElement(article) {
+    if (!article.image) return null;
     const wrapper = document.createElement('article');
     wrapper.className = 'article';
 
@@ -154,14 +167,12 @@
     if (trimmed) textWrap.appendChild(desc);
     wrapper.appendChild(textWrap);
 
-    if (article.image) {
-      const img = document.createElement('img');
-      img.className = 'article-thumb';
-      img.src = article.image;
-      img.alt = article.title;
-      img.loading = 'lazy';
-      wrapper.appendChild(img);
-    }
+    const img = document.createElement('img');
+    img.className = 'article-thumb';
+    img.src = article.image;
+    img.alt = article.title;
+    img.loading = 'lazy';
+    wrapper.appendChild(img);
 
     // Comments functionality has been removed to simplify the interface
 
@@ -174,7 +185,7 @@
   function buildTicker(newsData) {
     const allItems = [];
     Object.values(newsData).forEach(arr => {
-      allItems.push(...arr);
+      allItems.push(...arr.filter(a => a.image));
     });
     // Sort globally by pubDate
     allItems.sort((a, b) => parseDate(b.pubDate) - parseDate(a.pubDate));
@@ -225,14 +236,18 @@
         const matches = articles.filter(a => {
           return a.title.toLowerCase().includes(query) || a.description.toLowerCase().includes(query);
         });
-        if (matches.length === 0) {
+        const elements = [];
+        matches.forEach(item => {
+          const el = createArticleElement(item);
+          if (el) elements.push(el);
+        });
+
+        if (elements.length === 0) {
           const p = document.createElement('p');
           p.textContent = 'No results.';
           list.appendChild(p);
         } else {
-          matches.forEach(item => {
-            list.appendChild(createArticleElement(item));
-          });
+          elements.forEach(el => list.appendChild(el));
         }
         section.appendChild(list);
       });

--- a/styles.css
+++ b/styles.css
@@ -143,7 +143,7 @@ body {
   border-radius: 8px;
   object-fit: cover;
   border: 1px solid var(--line);
-  display: none; /* hidden by default; enabled at ≥720px */
+  display: block;
 }
 
 .article-meta {
@@ -224,7 +224,6 @@ body {
 /* ====== Responsive ====== */
 @media (min-width: 720px) {
   .article-list { grid-template-columns: 1fr 1fr; }
-  .article-thumb { display: block; }
 }
 @media (min-width: 1024px) {
   .article-list { grid-template-columns: 1fr 1fr 1fr; }


### PR DESCRIPTION
## Summary
- Enforce title, link, and image for gaming feed items and prioritize Steam releases
- Render only articles with images and show Steam entries first in the gaming section
- Display article thumbnails by default and exclude imageless items from ticker and search

## Testing
- `python -m py_compile fetch_news.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1f16457c8832dae9c5d971ddd7d7e