### PR TITLE
Fix gaming feed image extraction and prioritize section

### DIFF
--- a/data/news.json
+++ b/data/news.json
@@ -1,8 +1,477 @@
 {
-  "lastUpdate": "2025-08-29T19:16:15.708274Z",
+  "lastUpdate": "2025-08-29T19:21:44.566604Z",
   "news": {
-    "Gaming": [],
+    "Gaming": [
+      {
+        "title": "Now Available on Steam - SCUM",
+        "link": "https://store.steampowered.com/news/246601/",
+        "description": "",
+        "pubDate": "2025-06-17T14:55:24Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.fastly.steamstatic.com/steam/apps/513710/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Foundation, 25% off!",
+        "link": "https://store.steampowered.com/news/237790/",
+        "description": "",
+        "pubDate": "2025-01-31T15:03:00Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.fastly.steamstatic.com/steam/apps/690830/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - The Universim",
+        "link": "https://store.steampowered.com/news/215594/",
+        "description": "",
+        "pubDate": "2024-01-22T18:01:40Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/352720/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Cowbots and Aliens",
+        "link": "https://store.steampowered.com/news/214495/",
+        "description": "",
+        "pubDate": "2023-12-24T23:03:27Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.akamai.steamstatic.com/steam/apps/517670/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Kodon",
+        "link": "https://store.steampowered.com/news/213793/",
+        "description": "",
+        "pubDate": "2023-12-10T20:20:25Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/479010/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - RAILGRADE, 25% off!",
+        "link": "https://store.steampowered.com/news/210653/",
+        "description": "",
+        "pubDate": "2023-10-13T07:00:13Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.akamai.steamstatic.com/steam/apps/1355090/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Kynseed, 10% off!",
+        "link": "https://store.steampowered.com/news/166893/",
+        "description": "",
+        "pubDate": "2022-12-06T15:00:37Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/758870/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Quake Champions",
+        "link": "https://store.steampowered.com/news/142057/",
+        "description": "",
+        "pubDate": "2022-08-18T16:09:32Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/611500/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Good Company, 20% off!",
+        "link": "https://store.steampowered.com/news/139789/",
+        "description": "",
+        "pubDate": "2022-06-21T13:02:05Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.akamai.steamstatic.com/steam/apps/911430/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Raft, 15% off!",
+        "link": "https://store.steampowered.com/news/139741/",
+        "description": "",
+        "pubDate": "2022-06-20T16:56:52Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/648800/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Factory Town",
+        "link": "https://store.steampowered.com/news/101463/",
+        "description": "",
+        "pubDate": "2021-11-17T18:01:38Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.akamai.steamstatic.com/steam/apps/860890/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Ruined King: A League of Legends Story™",
+        "link": "https://store.steampowered.com/news/101398/",
+        "description": "",
+        "pubDate": "2021-11-16T16:25:13Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/1276790/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Killsquad, 20% off!",
+        "link": "https://store.steampowered.com/news/90261/",
+        "description": "",
+        "pubDate": "2021-10-21T10:09:19Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/910490/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Legion TD 2 - Multiplayer Tower Defense",
+        "link": "https://store.steampowered.com/news/89382/",
+        "description": "",
+        "pubDate": "2021-10-01T14:45:01Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/469600/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Rec Room",
+        "link": "https://store.steampowered.com/news/88237/",
+        "description": "",
+        "pubDate": "2021-09-02T18:04:00Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/471710/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Clone Drone in the Danger Zone, 15% off!",
+        "link": "https://store.steampowered.com/news/86805/",
+        "description": "",
+        "pubDate": "2021-07-27T13:59:53Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/597170/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Totally Accurate Battle Simulator",
+        "link": "https://store.steampowered.com/news/82651/",
+        "description": "",
+        "pubDate": "2021-04-01T18:01:18Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.akamai.steamstatic.com/steam/apps/508440/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "New DLC Available - ROMANCE OF THE THREE KINGDOMS XIV: Diplomacy and Strategy Expansion Pack, 10% off!",
+        "link": "https://store.steampowered.com/news/78720/",
+        "description": "",
+        "pubDate": "2020-12-10T01:04:00Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/1427650/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Dreadlands, 20% off!",
+        "link": "https://store.steampowered.com/news/77616/",
+        "description": "",
+        "pubDate": "2020-11-09T14:12:41Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/1054690/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Kine, 34% off!",
+        "link": "https://store.steampowered.com/news/76709/",
+        "description": "",
+        "pubDate": "2020-10-19T18:00:37Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/824570/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Noita, 20% off!",
+        "link": "https://store.steampowered.com/news/76583/",
+        "description": "",
+        "pubDate": "2020-10-15T17:03:09Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/881100/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Squad",
+        "link": "https://store.steampowered.com/news/75790/",
+        "description": "",
+        "pubDate": "2020-09-23T18:01:39Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/393380/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Stay Silent",
+        "link": "https://store.steampowered.com/news/75561/",
+        "description": "",
+        "pubDate": "2020-09-17T02:38:48Z",
+        "source": "store.steampowered.com",
+        "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/978180/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Risk of Rain 2",
+        "link": "https://store.steampowered.com/news/64370/",
+        "description": "",
+        "pubDate": "2020-08-11T14:54:28Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/632360/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Soviet Jump Game",
+        "link": "https://store.steampowered.com/news/63409/",
+        "description": "",
+        "pubDate": "2020-07-16T15:49:54Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/1072710/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Weekend Deal - The Elder Scrolls Franchise, 60-70% Off",
+        "link": "https://store.steampowered.com/news/62557/",
+        "description": "",
+        "pubDate": "2020-06-18T18:52:00Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/news/62557/social_media_share.jpg?t=1592505828",
+        "bias": 0
+      },
+      {
+        "title": "Free Weekend - Fallout 76",
+        "link": "https://store.steampowered.com/news/61359/",
+        "description": "",
+        "pubDate": "2020-05-14T17:10:00Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/1151340/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Deep Rock Galactic",
+        "link": "https://store.steampowered.com/news/61333/",
+        "description": "",
+        "pubDate": "2020-05-13T13:01:50Z",
+        "source": "store.steampowered.com",
+        "image": "https://media.st.dl.pinyuncloud.com/steam/apps/548430/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Resident Evil 3 Special Soundtrack",
+        "link": "https://store.steampowered.com/news/61170/",
+        "description": "",
+        "pubDate": "2020-05-07T16:01:08Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/1295160/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Now Available on Steam - Bellatia, 10% off!",
+        "link": "https://store.steampowered.com/news/61144/",
+        "description": "",
+        "pubDate": "2020-05-07T06:50:52Z",
+        "source": "store.steampowered.com",
+        "image": "https://steamcdn-a.akamaihd.net/steam/apps/614450/header.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Tower Defence - Roko Prodanović [Free]",
+        "link": "https://hu-iz-vi.itch.io/tower-defence-roko-prodanovi",
+        "description": "",
+        "pubDate": "2025-08-29T19:16:58Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyODkyLmpwZw==/315x250%23c/RsiC99.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Tower Defense - Eugen Juriša [Free]",
+        "link": "https://hu-iz-vi.itch.io/tower-defense",
+        "description": "",
+        "pubDate": "2025-08-29T19:09:50Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNzk1LnBuZw==/315x250%23c/LG6lxk.png",
+        "bias": 0
+      },
+      {
+        "title": "liminal tag [Free]",
+        "link": "https://caden25.itch.io/liminal-tag",
+        "description": "",
+        "pubDate": "2025-08-29T19:08:21Z",
+        "source": "caden25.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNzkzLnBuZw==/315x250%23c/RZllhb.png",
+        "bias": 0
+      },
+      {
+        "title": "The Void [Free] [Survival]",
+        "link": "https://barrerainteractive.itch.io/the-void",
+        "description": "Escape the Void and find powerful gems!",
+        "pubDate": "2025-08-29T18:54:55Z",
+        "source": "barrerainteractive.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNTgxLnBuZw==/315x250%23c/1By52E.png",
+        "bias": 0
+      },
+      {
+        "title": "Platformer - Matija Novaković [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platformer-matija-novakovi",
+        "description": "",
+        "pubDate": "2025-08-29T18:46:00Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNTAyLmpwZw==/315x250%23c/dL470D.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Platformer - Mateo Juretić [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platformer-mateo-juretic",
+        "description": "",
+        "pubDate": "2025-08-29T18:44:28Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNDc4LnBuZw==/315x250%23c/668lZ4.png",
+        "bias": 0
+      },
+      {
+        "title": "fouron_week1_2025 [Free]",
+        "link": "https://magicdoogies.itch.io/fouron-week1-2025",
+        "description": "",
+        "pubDate": "2025-08-29T18:42:26Z",
+        "source": "magicdoogies.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNDM4LmpwZw==/315x250%23c/fbevx%2B.jpg",
+        "bias": 0
+      },
+      {
+        "title": "How Fellers Have Tabled [Free] [Adventure] [Windows]",
+        "link": "https://guidogarbes.itch.io/how-fellers-have-tabled",
+        "description": "",
+        "pubDate": "2025-08-29T18:36:28Z",
+        "source": "guidogarbes.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyMzYwLnBuZw==/315x250%23c/FcDSmC.png",
+        "bias": 0
+      },
+      {
+        "title": "Platformer - Noa Živanović [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platformer-noa-ivanovi",
+        "description": "",
+        "pubDate": "2025-08-29T18:26:09Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyMjM5LnBuZw==/315x250%23c/JiA1B2.png",
+        "bias": 0
+      },
+      {
+        "title": "Platformer - Tihomir Beširović [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platformer-tihomir-beirovi",
+        "description": "",
+        "pubDate": "2025-08-29T18:25:29Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyMjMyLmpwZw==/315x250%23c/2uhxx%2B.jpg",
+        "bias": 0
+      },
+      {
+        "title": "The Tower of God [Free] [Role Playing]",
+        "link": "https://sjigsnark.itch.io/the-tower-of-god",
+        "description": "A poorly made roguelike.",
+        "pubDate": "2025-08-29T18:21:06Z",
+        "source": "sjigsnark.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyMzAzLnBuZw==/315x250%23c/9wS5iY.png",
+        "bias": 0
+      },
+      {
+        "title": "MineSweeper [Free] [Puzzle]",
+        "link": "https://itchyskink0.itch.io/minesweeper",
+        "description": "Minesweeper no ads",
+        "pubDate": "2025-08-29T18:17:59Z",
+        "source": "itchyskink0.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyMjM2LnBuZw==/315x250%23c/38Tl3N.png",
+        "bias": 0
+      },
+      {
+        "title": "Platformer - Marko Troskot [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platformer-marko-troskot",
+        "description": "",
+        "pubDate": "2025-08-29T18:08:26Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQxOTg4LnBuZw==/315x250%23c/%2FYFLcq.png",
+        "bias": 0
+      },
+      {
+        "title": "Biscuit Robbery [Free] [Platformer]",
+        "link": "https://coolwdv.itch.io/biscuit-robbery",
+        "description": "Rob the Golden Biscuit from the bank.",
+        "pubDate": "2025-08-29T18:05:09Z",
+        "source": "coolwdv.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQxNzk5LnBuZw==/315x250%23c/ljcCs6.png",
+        "bias": 0
+      },
+      {
+        "title": "Platofrmer - Marko Mišević [Free] [Platformer]",
+        "link": "https://hu-iz-vi.itch.io/platofrmer-nikola-mish",
+        "description": "",
+        "pubDate": "2025-08-29T18:04:25Z",
+        "source": "hu-iz-vi.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQxOTM2LmpwZw==/315x250%23c/KcuenR.jpg",
+        "bias": 0
+      },
+      {
+        "title": "A Colorful Life [Free] [Puzzle] [Windows]",
+        "link": "https://emi-allay.itch.io/a-colorful-life",
+        "description": "",
+        "pubDate": "2025-08-29T18:01:36Z",
+        "source": "emi-allay.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQxNzgyLnBuZw==/315x250%23c/20dFRa.png",
+        "bias": 0
+      },
+      {
+        "title": "cat jump [Free]",
+        "link": "https://natlov.itch.io/cat-jump",
+        "description": "",
+        "pubDate": "2025-08-29T17:54:36Z",
+        "source": "natlov.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyMTQ2LnBuZw==/315x250%23c/By1iap.png",
+        "bias": 0
+      },
+      {
+        "title": "Conveyor Line Chaos! [Free] [Other]",
+        "link": "https://jaredscode.itch.io/conveyor-line-chaos",
+        "description": "How long can you go before failing to pack all the items?",
+        "pubDate": "2025-08-29T17:42:25Z",
+        "source": "jaredscode.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQxNjI2LnBuZw==/315x250%23c/czzhsp.png",
+        "bias": 0
+      },
+      {
+        "title": "Scarity: The story of Dread [Free] [Visual Novel] [Windows] [macOS]",
+        "link": "https://halkind.itch.io/scarity",
+        "description": "Written By Mykhailo Halkind",
+        "pubDate": "2025-08-29T17:35:09Z",
+        "source": "halkind.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNjI3LnBuZw==/315x250%23c/Nr5oRQ.png",
+        "bias": 0
+      },
+      {
+        "title": "LE - The Quest for the Castle [Free]",
+        "link": "https://visst.itch.io/le-the-quest-for-the-king",
+        "description": "",
+        "pubDate": "2025-08-29T17:35:06Z",
+        "source": "visst.itch.io",
+        "image": "https://img.itch.zone/aW1nLzIyOTQyNTU4LnBuZw==/315x250%23c/%2B6SxDa.png",
+        "bias": 0
+      }
+    ],
     "World": [
+      {
+        "title": "How Israeli spy veterans are shaping US Big Tech",
+        "link": "https://www.aljazeera.com/video/the-take-2/2025/8/29/how-israeli-spy-veterans-are-shaping-us-big-tech?traffic_source=rss",
+        "description": "Hundreds of Israeli intelligence veterans are in US Big Tech and it’s raising questions about data and security.",
+        "pubDate": "2025-08-29T19:13:56Z",
+        "source": "aljazeera.com",
+        "image": "",
+        "bias": -1
+      },
+      {
+        "title": "Children’s aid site in Gaza city shows ‘signs of famine everywhere’",
+        "link": "https://www.aljazeera.com/video/newsfeed/2025/8/29/childrens-aid-site-in-gaza-city-shows-signs-of-famine?traffic_source=rss",
+        "description": "UNICEF says \"famine is absolutely ravaging Gaza City.\"",
+        "pubDate": "2025-08-29T19:08:23Z",
+        "source": "aljazeera.com",
+        "image": "",
+        "bias": -1
+      },
       {
         "title": "US to stop Palestinians attending UN meeting in New York",
         "link": "https://www.bbc.com/news/articles/cjdym32z9v7o?at_medium=RSS&at_campaign=rss",
@@ -19,6 +488,15 @@
         "pubDate": "2025-08-29T18:49:54Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/8743/live/bedcbc10-84cb-11f0-b391-6936825093bd.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Stocks pull back from their latest all-time highs on Wall Street - AP News",
+        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxQZWd4VFJlcExVMmFYN0RXVGVyZVpQNnBOUXU0bzdGZjV5Um53VG9ZOWJ4THQ5NWRMVDg2Sl8tS1lmcUJaRWRwNXBLYWh4QUxCUVJNZURSVkttR3pFSmI4dlIzVTJ5VzRBOWVZYUJFdlg2MWQtZUtYV2oyeUtHaGFuZ242dzdLVmQxRjVEclFCWkNzNjVCaWJPR3ZxREs?oc=5",
+        "description": "",
+        "pubDate": "2025-08-29T18:42:00Z",
+        "source": "news.google.com",
+        "image": "",
         "bias": 0
       },
       {
@@ -64,15 +542,6 @@
         "pubDate": "2025-08-29T17:49:18Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/1b87/live/503f8640-8500-11f0-93e1-1bc78abed30d.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Stocks pull back from their latest all-time highs on Wall Street - AP News",
-        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxQZWd4VFJlcExVMmFYN0RXVGVyZVpQNnBOUXU0bzdGZjV5Um53VG9ZOWJ4THQ5NWRMVDg2Sl8tS1lmcUJaRWRwNXBLYWh4QUxCUVJNZURSVkttR3pFSmI4dlIzVTJ5VzRBOWVZYUJFdlg2MWQtZUtYV2oyeUtHaGFuZ242dzdLVmQxRjVEclFCWkNzNjVCaWJPR3ZxREs?oc=5",
-        "description": "",
-        "pubDate": "2025-08-29T17:40:00Z",
-        "source": "news.google.com",
-        "image": "",
         "bias": 0
       },
       {
@@ -125,6 +594,15 @@
         "link": "https://news.google.com/rss/articles/CBMikwFBVV95cUxPVFNWR0pTU2hOUDJ2cTdKS29sSlVhckFvaEFEQk9DejhLdm9ySG9VOW8ySUY3SmNQeDhELWZiVnZQWjh1QzZoazlFVzRtdVpsTk5yTlZNNjRYaEtNb0ZlTUVWVk15Ql9xUjRPdzU3Y3F3MlFZWHpMajRMV3JvSW8zUTRhV2c4SjRaTl9McHNtVkpaeDQ?oc=5",
         "description": "",
         "pubDate": "2025-08-29T17:04:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Tensions soar in Indonesia as protests over police brutality and lawmakers' allowances continue - AP News",
+        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxNdDFsU3RnYWFza0tHbnl0emhPMnZ5TE1pUDNTUUJsbjFkSE1Tam9HdWZ3a1U4TDNuZk1WNFBWY3lsczV5YlJzb3ZCaEYtLUF2MDlsM1VrdGstd25KME9nMmhaeGJrS09VTTlYYlVpQ25JQTFfcGxyMzUyRVBQMXlqZHFJMkxxQjh1ZWpSSjl2dHY?oc=5",
+        "description": "",
+        "pubDate": "2025-08-29T17:02:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0
@@ -202,15 +680,6 @@
         "bias": -1
       },
       {
-        "title": "MLB | Latest News, Stats, and Scores - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiP0FVX3lxTFBaTkhyRGJFdHFXZVFvanhPRFAxZmlEWjZWRDJxNWFVRzZGT2I1Zm1kNmVLLU9Henk1d2M5dFFDRQ?oc=5",
-        "description": "",
-        "pubDate": "2025-08-29T16:16:04Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
         "title": "‘I am in no rush’: Brazil’s Lula weighs countermeasures to Trump’s tariffs",
         "link": "https://www.aljazeera.com/news/2025/8/29/i-am-in-no-rush-brazils-lula-weighs-countermeasures-to-trumps-tariffs?traffic_source=rss",
         "description": "Brazil currently faces 50 percent tariffs on many of its US exports, as a result of its prosecution of Jair Bolsonaro.",
@@ -218,6 +687,15 @@
         "source": "aljazeera.com",
         "image": "",
         "bias": -1
+      },
+      {
+        "title": "MLB | Latest News, Stats, and Scores - AP News",
+        "link": "https://news.google.com/rss/articles/CBMiP0FVX3lxTFBaTkhyRGJFdHFXZVFvanhPRFAxZmlEWjZWRDJxNWFVRzZGT2I1Zm1kNmVLLU9Henk1d2M5dFFDRQ?oc=5",
+        "description": "",
+        "pubDate": "2025-08-29T16:05:57Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
       },
       {
         "title": "Want to work for National Weather Service? Be ready to explain how you agree with Trump - AP News",
@@ -274,8 +752,8 @@
         "bias": -1
       },
       {
-        "title": "Trump suggests more US cities need National Guard but crime stats tell a different story - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxQOGFqdHVWdXotNXlFMG9IX19sQWI1QzVkeUg3WlJVdFczR0lZNjFHdTZMOWpDcUxMX3hTZVdCODVOYUVSTmlNSzJtQl8yb1JHTlItZ0ZrX1FiRUxYRFNXUVd1MklZWHh4ejB4TmJPQWZWdEtEdXNic2ppYjFLRkMzdFpuaVRlUFhFLUUtWFpWa0lVY1VZejhR?oc=5",
+        "title": "Italian swimmers returning home from worlds detained briefly at Singapore airport for shoplifting - AP News",
+        "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxQUHN1dGNEdmQ1bXY1UU1KcHVKTHNjNkRMUWV4WFZzeUlQOW5vdnAwYUNDOFd4cWZDd19tSUtwRjVjMDR3SV82Wi1qNV9FWG9GN1FvQWN0OUVndTJETXV2Qk93ZlFpNmRVYVluWHFXODhKUF95d2FxWUxueV8tX1QyZVdnZFFaYXVPRTNicl96cG9KdDJUR081QnB2Q2t5Unky?oc=5",
         "description": "",
         "pubDate": "2025-08-29T15:07:00Z",
         "source": "news.google.com",
@@ -283,8 +761,8 @@
         "bias": 0
       },
       {
-        "title": "Italian swimmers returning home from worlds detained briefly at Singapore airport for shoplifting - AP News",
-        "link": "https://news.google.com/rss/articles/CBMioAFBVV95cUxQUHN1dGNEdmQ1bXY1UU1KcHVKTHNjNkRMUWV4WFZzeUlQOW5vdnAwYUNDOFd4cWZDd19tSUtwRjVjMDR3SV82Wi1qNV9FWG9GN1FvQWN0OUVndTJETXV2Qk93ZlFpNmRVYVluWHFXODhKUF95d2FxWUxueV8tX1QyZVdnZFFaYXVPRTNicl96cG9KdDJUR081QnB2Q2t5Unky?oc=5",
+        "title": "Trump suggests more US cities need National Guard but crime stats tell a different story - AP News",
+        "link": "https://news.google.com/rss/articles/CBMilwFBVV95cUxQOGFqdHVWdXotNXlFMG9IX19sQWI1QzVkeUg3WlJVdFczR0lZNjFHdTZMOWpDcUxMX3hTZVdCODVOYUVSTmlNSzJtQl8yb1JHTlItZ0ZrX1FiRUxYRFNXUVd1MklZWHh4ejB4TmJPQWZWdEtEdXNic2ppYjFLRkMzdFpuaVRlUFhFLUUtWFpWa0lVY1VZejhR?oc=5",
         "description": "",
         "pubDate": "2025-08-29T15:07:00Z",
         "source": "news.google.com",
@@ -425,33 +903,6 @@
         "source": "news.google.com",
         "image": "",
         "bias": 0
-      },
-      {
-        "title": "Fed Governor Cook in court to block Trump from firing her",
-        "link": "https://www.bbc.com/news/articles/cedvj2d5538o?at_medium=RSS&at_campaign=rss",
-        "description": "The legal case over Trump's move could have lasting implications for the central bank's independence.",
-        "pubDate": "2025-08-29T12:34:51Z",
-        "source": "bbc.com",
-        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/c553/live/5e6d4270-8262-11f0-ba76-2552413beb48.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Tensions soar across Indonesia as protests against police erupt in multiple cities - AP News",
-        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxNdDFsU3RnYWFza0tHbnl0emhPMnZ5TE1pUDNTUUJsbjFkSE1Tam9HdWZ3a1U4TDNuZk1WNFBWY3lsczV5YlJzb3ZCaEYtLUF2MDlsM1VrdGstd25KME9nMmhaeGJrS09VTTlYYlVpQ25JQTFfcGxyMzUyRVBQMXlqZHFJMkxxQjh1ZWpSSjl2dHY?oc=5",
-        "description": "",
-        "pubDate": "2025-08-29T12:32:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "How Trump’s newfound love for Chinese students is drawing MAGA backlash",
-        "link": "https://www.aljazeera.com/news/2025/8/29/how-trumps-newfound-love-for-chinese-students-is-drawing-maga-backlash?traffic_source=rss",
-        "description": "Trump said he would allow Chinese students into US universities, months after administration announced visa revocations.",
-        "pubDate": "2025-08-29T12:18:01Z",
-        "source": "aljazeera.com",
-        "image": "",
-        "bias": -1
       }
     ],
     "Politics": [
@@ -615,15 +1066,6 @@
         "pubDate": "2025-08-29T05:23:56Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/560f/live/12b1c6f0-8431-11f0-948c-5bc66b89f4bb.jpg",
-        "bias": 0
-      },
-      {
-        "title": "CDC gets new acting director as leadership turmoil leaves agency reeling - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxPd180RUcwMEJPaERVdmZ1cnU5MkVqamxCV1hJVm5PTkJrenJEUUNjblI3anpOMXpfZ1NMa19neGI0Rkk4M3BZSi12ZWhwVFg3TTdicnBxZU1JOXRIaW4xSndsVHZrSHBKQm16a0tDTHNUZDN2cE01WlV3cFh6b3FMTXJOSnNFdEJTVW1fai1KbF9HbnFfYzVpMDc4R3NWandDa3BEYlptdDMxMUZy?oc=5",
-        "description": "",
-        "pubDate": "2025-08-29T00:04:00Z",
-        "source": "news.google.com",
-        "image": "",
         "bias": 0
       },
       {
@@ -904,9 +1346,27 @@
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/a151/live/61694690-8271-11f0-a832-3d1a9236e27e.jpg",
         "bias": 0
+      },
+      {
+        "title": "Another French prime minister could be toppled. More political instability is ahead - AP News",
+        "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxOSk5lNkhOMDBWZl9aRmk5MnpXOWdlUG5xZUY4dmszaEtiZ2RfZ2tkY1AxbnNDeE1MMlNOUHN2MVBheTJYTkdKVjZDRDRDby1ESG5DRm5XWDNvUjk5VHMwbGRoMG5RLUJuUlViU202UGpOdGd6TTZrcndMMUhnVnE3TWVtNzRTdVIwanowUTVVRmljYjJLUkhyU25OSV9TN0dTSzdGamF6WUtfcmFGVXc?oc=5",
+        "description": "",
+        "pubDate": "2025-08-26T11:46:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
       }
     ],
     "Tech": [
+      {
+        "title": "Tensions soar across Indonesia as protests against police erupt in multiple cities - AP News",
+        "link": "https://news.google.com/rss/articles/CBMikAFBVV95cUxNdDFsU3RnYWFza0tHbnl0emhPMnZ5TE1pUDNTUUJsbjFkSE1Tam9HdWZ3a1U4TDNuZk1WNFBWY3lsczV5YlJzb3ZCaEYtLUF2MDlsM1VrdGstd25KME9nMmhaeGJrS09VTTlYYlVpQ25JQTFfcGxyMzUyRVBQMXlqZHFJMkxxQjh1ZWpSSjl2dHY?oc=5",
+        "description": "",
+        "pubDate": "2025-08-29T17:02:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
       {
         "title": "Court documents shed new light on UK-Apple row over user data",
         "link": "https://www.bbc.com/news/articles/cx293qg7z39o?at_medium=RSS&at_campaign=rss",
@@ -1067,15 +1527,6 @@
         "pubDate": "2025-08-27T21:03:24Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/d867/live/8df2c140-8295-11f0-bda8-213e434b329e.jpg",
-        "bias": 0
-      },
-      {
-        "title": "Judge questions if Spanish-language journalist can stay in immigration detention without charges - AP News",
-        "link": "https://news.google.com/rss/articles/CBMirwFBVV95cUxPSTZ5ZGZFUGtsa2JvNmpPOVNNWjZPNkRwT3ZmRUo5LXVtdUhoUlljWHJZSEVMa3dBUHNPQ2RhbHVDNUl6bTVMTVhxczVjdFFDZUxObGtnYUl6Qm01Nl96czlTaVpNUDlNQmRlWlpTdVphVnFwc1MxZExvcHR4ZU9RblpoazJsdFNKcm43clRrZVV4cEZOdkpQSWJraTNXUXBfc3RGTVVkYlhfR0tSUFI0?oc=5",
-        "description": "",
-        "pubDate": "2025-08-27T18:42:00Z",
-        "source": "news.google.com",
-        "image": "",
         "bias": 0
       },
       {
@@ -1378,6 +1829,15 @@
         "bias": -1
       },
       {
+        "title": "CDC gets new acting director as leadership turmoil leaves agency reeling - AP News",
+        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxPd180RUcwMEJPaERVdmZ1cnU5MkVqamxCV1hJVm5PTkJrenJEUUNjblI3anpOMXpfZ1NMa19neGI0Rkk4M3BZSi12ZWhwVFg3TTdicnBxZU1JOXRIaW4xSndsVHZrSHBKQm16a0tDTHNUZDN2cE01WlV3cFh6b3FMTXJOSnNFdEJTVW1fai1KbF9HbnFfYzVpMDc4R3NWandDa3BEYlptdDMxMUZy?oc=5",
+        "description": "",
+        "pubDate": "2025-08-29T00:04:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
         "title": "Trump administration argues that more roads would help against wildfires",
         "link": "https://www.npr.org/2025/08/28/nx-s1-5468957/trump-administration-argues-that-more-roads-would-help-against-wildfires",
         "description": "The Trump administration is citing wildfire suppression as the reason it's seeking to undo the Roadless Rule. Science suggests more roads will cause more fires.",
@@ -1531,15 +1991,6 @@
         "bias": -1
       },
       {
-        "title": "Democratic senator warns of 'Power 2' owning college sports if NCAA-backed SCORE Act becomes law - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilAFBVV95cUxQMUZIMWJ3TzRNdGozeDNtUjFjelNWYmZJeTVUY0tpdFd3MzFmdUw0WTBkWFVCS2ZKYU5TUlpYTE9lMS1hOUg3ZGx3UG1sUV9iQ2VTYnhlRUd5SkotZUttZXhjSURmZDlwc0ZGVDdxMDZIRUR3YTExdzZFWTZfR2xwUFVOX0JhV2gxSEZBREphQklROXN4?oc=5",
-        "description": "",
-        "pubDate": "2025-08-25T16:43:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
         "title": "Climate change pushing winemakers to blend wines from different years",
         "link": "https://www.bbc.com/news/articles/czxp41y3n7lo?at_medium=RSS&at_campaign=rss",
         "description": "Non-vintage still wine is now increasingly being made in response to more challenging weather.",
@@ -1684,24 +2135,6 @@
         "bias": 0
       },
       {
-        "title": "Scientists standing by to rescue rare manatee sighted in cold New England waters - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitwFBVV95cUxOWEZweURmZDBnRXk0cU9KVFlTaWNCVDc1WWpmZmpoLXp2QzZiNmszSlNaRjJOaTNSczA4bFdpWi1mU0Y5VGFVaDhOd2pKMzhycTJkZWpkVUJHMVFiejVnckpjenhlREwzM1Y2ckdtRy1ENU1FYnE4aXZPUmR5NzRUS1FlUEw5aElISlpPOUFJZWptc0Y3UnNwQzVGMXZ5YjE4ckNvVlEtM3R6QlVEM2pGWWQwWTB0bXc?oc=5",
-        "description": "",
-        "pubDate": "2025-08-12T07:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Scientists search for DNA of an endangered salamander in Mexico City’s canals - AP News",
-        "link": "https://news.google.com/rss/articles/CBMiowFBVV95cUxPOHF3TDVhWTVmRG5KZDJvVkQ2Q3BLMXhTUHNVVDhvR2p0ZEhZWWxYMkJZZ3FodjRISlRUb3VHdXRrODI4aEFjSjdhbUpJWEtIQjU5UmtQTTVDbW02T3pEcnctd3RGTld6T2VwWnEwMnBKSjdxcWRDeHgwdlVoLU53aWhfeF9yZmlGV2dDUEhFbkJvQUwySExpVmsxNHlXSXlkaXpj?oc=5",
-        "description": "",
-        "pubDate": "2025-08-11T07:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
         "title": "Jim Lovell, Apollo 13 astronaut, dies aged 97",
         "link": "https://www.bbc.com/news/articles/cl7y8zq5xpno?at_medium=RSS&at_campaign=rss",
         "description": "The commander of Apollo 13 famously rescued his men from near certain death in space.",
@@ -1731,15 +2164,6 @@
       {
         "title": "Scientists thought this Argentine glacier was stable. Now they say it’s melting fast - AP News",
         "link": "https://news.google.com/rss/articles/CBMitwFBVV95cUxOalo3dFBDS2Itc0ZoaFJheVlZd29XYVVGT3ZfWWUxVWxYNFI0N0tuZ0tlWUlqTTl0TDNsR2FfQlJjcmhNOUJLUzh5eHR3VU9xZVlYT3V4REpHSzRKeVVNS3NUV1ZBT1FPa1NrVjhNeVlJZnNOcldoMS1FazNIZzY3bWZZVUt1TnltSmJ3cTV3aXZydTZnMmdNbTNkbUdoOFJlck5hcEJHS2l6Tno0X19vRDVMaVdmN3c?oc=5",
-        "description": "",
-        "pubDate": "2025-08-07T07:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "A livestream of deep sea creatures transfixes Argentina and sparks calls for refunding science - AP News",
-        "link": "https://news.google.com/rss/articles/CBMitgFBVV95cUxPOGZDLVc0UmROT3NXNHUzaGNSQkJPeXBuSk9rNW1ZNXIwMnNCdmZOMm1VcGh6OGFaQkhpMXYzS1VLemdESjRsVW1JQ0t2Yjl6SDlIRjl0ZGVhN0hybTdwSXZ3WW9aR0pRdDh3ZXExRGdiaHBDZ2VFSHNzTDE2RzBiNFVLWms0SVlQQzZiTFRkMUxXeFNRdXB2RFNFeEZ3NzVSd2FCSVRRcWQyZURHQkRoN0p4dkYxUQ?oc=5",
         "description": "",
         "pubDate": "2025-08-07T07:00:00Z",
         "source": "news.google.com",
@@ -1807,6 +2231,33 @@
         "pubDate": "2025-08-03T09:05:37Z",
         "source": "bbc.com",
         "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/ca33/live/e0d71e40-7059-11f0-8dbd-f3d32ebd3327.jpg",
+        "bias": 0
+      },
+      {
+        "title": "Melting glaciers threaten to wipe out European villages - is the steep cost to protect them worth it?",
+        "link": "https://www.bbc.com/news/articles/cj4w9ggzxv4o?at_medium=RSS&at_campaign=rss",
+        "description": "Switzerland spends almost $500m a year on protective structures. Is it worth it - or, as some suggest, should people move away from the mountain villages at risk?",
+        "pubDate": "2025-08-02T23:06:56Z",
+        "source": "bbc.com",
+        "image": "https://ichef.bbci.co.uk/ace/standard/240/cpsprodpb/2ae0/live/32850770-6ecf-11f0-af20-030418be2ca5.png",
+        "bias": 0
+      },
+      {
+        "title": "Judge allows the National Science Foundation to withhold hundreds of millions of research dollars - AP News",
+        "link": "https://news.google.com/rss/articles/CBMilAFBVV95cUxNbnpNUDVSRUhTc2hPN3QtdEdwRTU0WDhVR0psUy1ieUdZbU1ZRFZYN252eUdVRUozTTZtQlJGbElpZGhzcmRZaHFLOGJtY0NVd1pKaGZIWVZCa0RUdVRJN0w2VDNwX0pKeW9MWkExeWhXTDRPMkE3TE1fQUVqX2M4NDR3VnZ4RGJTczdmMG9lcHFtTEM0?oc=5",
+        "description": "",
+        "pubDate": "2025-08-01T07:00:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
+        "title": "Scientists in South Africa are making rhino horns radioactive to fight poaching - AP News",
+        "link": "https://news.google.com/rss/articles/CBMinAFBVV95cUxNV3UyVnZQa2ZMb0xQLVo5TWJKb29xOWdzNC0yYndDN0hFeXdyUzQ4WVdCUWhYQ2NRSTlYOS1fRUZwalFwNmtoRmRmM3lVSzdnTnJya3VodmJzdGk5ZTgxN0FGS2xZYWtxMkx0QUtHSFVGNThPYmZ0VDZZc2FvWGh4ZUxnWjNfSVBVQ283NWdmV195RTYzS1c2NGlsby0?oc=5",
+        "description": "",
+        "pubDate": "2025-07-31T07:00:00Z",
+        "source": "news.google.com",
+        "image": "",
         "bias": 0
       }
     ],
@@ -2651,6 +3102,15 @@
         "bias": 0
       },
       {
+        "title": "'KPop Demon Hunters': How Netflix's animated film became a hit - AP News",
+        "link": "https://news.google.com/rss/articles/CBMirAFBVV95cUxQRWgxWnJhWjlEOG1qZDZxMjJ6eGdMYTNCV0RTaTNhQ3QxY2VDS1NKQlE4S1JScHpzQmF6clRpRlkwZElWM1pKS3R0ZDdrWDI4NVhSdkFyZE1xOGdtSHdrYXdneXREUXROTjNHcHBtTVJvaDUtVm1QV3o2ME94Tk16TkIxSTBoY1hzT1lUdDVvRkYxLW5TQjIyVzB3THFQT3BZNzBhakt3VThfdXdu?oc=5",
+        "description": "",
+        "pubDate": "2025-07-30T07:00:00Z",
+        "source": "news.google.com",
+        "image": "",
+        "bias": 0
+      },
+      {
         "title": "The reverse migration: African Americans relocating to Kenya cite heritage and restoration - AP News",
         "link": "https://news.google.com/rss/articles/CBMimgFBVV95cUxNeTlKTWd2aUIwVFFmYlBWUGlHT0szNnF1aTVCRHFwYU5FdGdiTWZqRG1BZDRuZEZnOUJrc0s5Q0twSnFrNjh6R1BVenI3OHc3Q3JwM292OE01ME1VcjFBVGFUZFlMNXBSaEtBbTRnc2hPQkxzcVBTaXgyVWhQWGNJdVBGZlVaVTUxSmFWSDBEMkNCbWIwTzB2LWxn?oc=5",
         "description": "",
@@ -2700,15 +3160,6 @@
         "link": "https://news.google.com/rss/articles/CBMirgFBVV95cUxNaTJjaEtLUHhnTTVFT0o2UTh4SEg4ZVFzLVRBNmFaSFpWZE5ubVdGUUd4R2IyYzBTN3pfUEUtNFVqZWJhc3lNdGlVVHlhbC05eDBydVRDRkxtbG1MVUx6S3VQVE9RTjhpWDRhNkNqZTlXY3BuYnZvN0NXTGFkVUQyc3I1SWxHRWwwQWQ5VTUyV2NDOXdiOU12UC03Q2Q3RkpyVURabGpTOFlpUllKcXc?oc=5",
         "description": "",
         "pubDate": "2025-05-14T07:00:00Z",
-        "source": "news.google.com",
-        "image": "",
-        "bias": 0
-      },
-      {
-        "title": "Book Review: From incels to trad wives, culture critic probes 21st century backlash against feminism - AP News",
-        "link": "https://news.google.com/rss/articles/CBMilgFBVV95cUxQZGpTQTFlMjdMTVNzZU85VVpMU1liZE05UFpKcGVKeGRYcjhVMkQ1T3NGUHk3REk4aWVnUkdPMnREcThsUF9OLS1TZ25QS0VRUzVKd19HVW1OeWtSU3l6QlgxTWZVYXJZNll2aDhDTGlLOU00S0xNR0h0dFBvRUVaSGpsOXR6UlQ0ZG1mdXI2V2JjUWJUTUE?oc=5",
-        "description": "",
-        "pubDate": "2025-04-28T07:00:00Z",
         "source": "news.google.com",
         "image": "",
         "bias": 0

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -21,6 +21,7 @@ import email.utils
 import html
 import os
 import concurrent.futures
+import re
 from urllib.parse import urlparse
 
 
@@ -109,6 +110,16 @@ def extract_items(xml_data: bytes) -> list:
             thumb = elem.find('{http://search.yahoo.com/mrss/}thumbnail')
             if thumb is not None:
                 image_url = thumb.attrib.get('url', '')
+        if not image_url:
+            img_tag = elem.find('imageurl')
+            if img_tag is not None:
+                image_url = img_tag.text or ''
+        if not image_url and description:
+            match = re.search(r'<img[^>]+src="([^"]+)"', description)
+            if not match:
+                match = re.search(r"<img[^>]+src='([^']+)'", description)
+            if match:
+                image_url = match.group(1)
 
         pub = elem.findtext('pubDate') or elem.findtext('{http://www.w3.org/2005/Atom}published') or ''
         pub_date = parse_pub_date(pub)

--- a/script.js
+++ b/script.js
@@ -42,8 +42,9 @@
         tickerContent.innerHTML = '';
 
         const categories = Object.keys(data.news);
+        categories.sort((a, b) => (a === 'Gaming' ? -1 : b === 'Gaming' ? 1 : 0));
         buildNav(categories);
-        buildSections(data.news);
+        buildSections(data.news, categories);
         buildTicker(data.news);
         attachSearch(data.news);
       })
@@ -83,8 +84,9 @@
   /**
    * Build the main news sections for each category.
    */
-  function buildSections(newsData) {
-    Object.entries(newsData).forEach(([category, articles]) => {
+  function buildSections(newsData, categories) {
+    categories.forEach(category => {
+      const articles = newsData[category] || [];
       const section = document.createElement('section');
       section.id = category.toLowerCase();
       const heading = document.createElement('h2');


### PR DESCRIPTION
## Summary
- extract images from custom tags and HTML descriptions so gaming feeds populate correctly
- ensure Gaming category appears first in navigation and sections

## Testing
- `python fetch_news.py`
- `python -m py_compile fetch_news.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1fd16d414832d9a0d363198ddefe4