### PR TITLE
Ensure only current-day news is displayed

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -161,6 +161,7 @@ def main():
 
     aggregated = {}
     global_titles = set()
+    today = datetime.datetime.utcnow().date()
 
     for category, urls in feeds.items():
         aggregated[category] = []
@@ -175,7 +176,10 @@ def main():
                 for item in items:
                     # Deduplicate by title across all categories
                     title_key = item['title'].strip().lower()
-                    if title_key in global_titles:
+                    pub_date = datetime.datetime.fromisoformat(
+                        item['pubDate'].replace('Z', '+00:00')
+                    ).date()
+                    if pub_date != today or title_key in global_titles:
                         continue
                     global_titles.add(title_key)
                     aggregated[category].append(item)

--- a/script.js
+++ b/script.js
@@ -36,6 +36,16 @@
     fetch('data/news.json')
       .then(res => res.json())
       .then(data => {
+        const today = new Date();
+        const isSameDay = d =>
+          d.getUTCFullYear() === today.getUTCFullYear() &&
+          d.getUTCMonth() === today.getUTCMonth() &&
+          d.getUTCDate() === today.getUTCDate();
+        Object.keys(data.news).forEach(cat => {
+          data.news[cat] = data.news[cat].filter(item =>
+            isSameDay(parseDate(item.pubDate))
+          );
+        });
         // Clear existing content before rebuilding
         navContainer.innerHTML = '';
         contentContainer.innerHTML = '';
@@ -53,9 +63,9 @@
       });
   }
 
-  // Initial fetch and subsequent refresh every 10 minutes
+  // Initial fetch and subsequent refresh every 15 minutes
   fetchAndRender();
-  setInterval(fetchAndRender, 10 * 60 * 1000);
+  setInterval(fetchAndRender, 15 * 60 * 1000);
 
   /**
    * Build the category navigation buttons.


### PR DESCRIPTION
## Summary
- filter out any articles not published today when generating `news.json`
- discard outdated items on the client and refresh content every 15 minutes

## Testing
- `python fetch_news.py`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b200ad07d0832da3115bcb2b4a12fc